### PR TITLE
Split single-line Function node JS onto separate statements

### DIFF
--- a/add-datetime-to-file-names/main.ts
+++ b/add-datetime-to-file-names/main.ts
@@ -8,7 +8,8 @@ const myFlow = flow.create('3fcd90e9-d470-4ad7-9ddd-dccdaf2f2b1f', 'Imported Add
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10020', 'Core.Programming.Function', 'Build Default Folder', {
-      func: `msg.default_folder = global.get('$Home$') + '/templates/desktop-automation/add-datetime-to-file-names/fixtures'; return msg;`,
+      func: `msg.default_folder = global.get('$Home$') + '/templates/desktop-automation/add-datetime-to-file-names/fixtures';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask Folder', {
       inTitle: Custom('Add datetime to file names'),
@@ -44,7 +45,12 @@ const myFlow = flow.create('3fcd90e9-d470-4ad7-9ddd-dccdaf2f2b1f', 'Imported Add
 
   f.node('a10012', 'Core.Programming.Function', 'Skip Dirs And Stamped', {
     outputs: 2,
-    func: `var f = msg.current_file || {}; if (f.IsDir) return [null, msg]; msg.source_path = f.Name; msg.create_time = f.CreateTime; if (/-\\d{8}\\./.test(f.Name)) return [null, msg]; return [msg, null];`,
+    func: `var f = msg.current_file || {};
+if (f.IsDir) return [null, msg];
+msg.source_path = f.Name;
+msg.create_time = f.CreateTime;
+if (/-\\d{8}\\./.test(f.Name)) return [null, msg];
+return [msg, null];`,
   });
 
   f.node('a10013', 'Robomotion.DateTime.Format', 'Format Stamp', {
@@ -55,7 +61,15 @@ const myFlow = flow.create('3fcd90e9-d470-4ad7-9ddd-dccdaf2f2b1f', 'Imported Add
     outFormattedTime: Message('stamp'),
   })
     .then('a10014', 'Core.Programming.Function', 'Build New Path', {
-      func: `var p = msg.source_path; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); var dir = p.substring(0, lastSlash); var base = p.substring(lastSlash + 1); var dot = base.lastIndexOf('.'); var stem = dot === -1 ? base : base.substring(0, dot); var ext = dot === -1 ? '' : base.substring(dot); msg.target_path = dir + '/' + stem + '-' + msg.stamp + ext; return msg;`,
+      func: `var p = msg.source_path;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+var dir = p.substring(0, lastSlash);
+var base = p.substring(lastSlash + 1);
+var dot = base.lastIndexOf('.');
+var stem = dot === -1 ? base : base.substring(0, dot);
+var ext = dot === -1 ? '' : base.substring(dot);
+msg.target_path = dir + '/' + stem + '-' + msg.stamp + ext;
+return msg;`,
     })
     .then('a10015', 'Core.FileSystem.PathExists', 'Target Exists?', {
       inPath: Message('target_path'),

--- a/add-datetime-to-file-names/subflows/a11000.ts
+++ b/add-datetime-to-file-names/subflows/a11000.ts
@@ -3,7 +3,11 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/add-datetime-to-file-names/fixtures'; msg._dl_dir = fixtures; msg._dl_invoice_txt = fixtures + '/invoice.txt'; msg._dl_report_txt = fixtures + '/report.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/add-datetime-to-file-names/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_invoice_txt = fixtures + '/invoice.txt';
+msg._dl_report_txt = fixtures + '/report.txt';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/concatenate-text-files/main.ts
+++ b/concatenate-text-files/main.ts
@@ -6,7 +6,10 @@ const myFlow = flow.create('a07ddc8e-02f0-4a3e-814e-a452561fb758', 'Imported Con
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/concatenate-text-files/fixtures'; msg.fixtures_dir = fixtures; msg.output_file_path = fixtures + '/ConcatenatedFiles.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/concatenate-text-files/fixtures';
+msg.fixtures_dir = fixtures;
+msg.output_file_path = fixtures + '/ConcatenatedFiles.txt';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.MessageBox', 'Show Description', {
       inTitle: Custom('Description'),
@@ -16,7 +19,8 @@ const myFlow = flow.create('a07ddc8e-02f0-4a3e-814e-a452561fb758', 'Imported Con
       optType: 'info',
     })
     .then('a10003', 'Core.Programming.Function', 'Seed File List', {
-      func: `msg.files_to_concatenate = [msg.fixtures_dir + '/part1.txt', msg.fixtures_dir + '/part2.txt']; return msg;`,
+      func: `msg.files_to_concatenate = [msg.fixtures_dir + '/part1.txt', msg.fixtures_dir + '/part2.txt'];
+return msg;`,
     })
     .then('a10004', 'Core.FileSystem.Delete', 'Clean Previous Output', {
       inPath: Message('output_file_path'),
@@ -39,7 +43,10 @@ const myFlow = flow.create('a07ddc8e-02f0-4a3e-814e-a452561fb758', 'Imported Con
     outContent: Message('current_file_contents'),
   })
     .then('a10011', 'Core.Programming.Function', 'Build Output Path', {
-      func: `var lastSlash = Math.max(msg.current_file.lastIndexOf('/'), msg.current_file.lastIndexOf('\\\\')); msg.output_path = msg.current_file.substring(0, lastSlash) + '/ConcatenatedFiles.txt'; msg.line_to_write = msg.current_file_contents + '\\n'; return msg;`,
+      func: `var lastSlash = Math.max(msg.current_file.lastIndexOf('/'), msg.current_file.lastIndexOf('\\\\'));
+msg.output_path = msg.current_file.substring(0, lastSlash) + '/ConcatenatedFiles.txt';
+msg.line_to_write = msg.current_file_contents + '\\n';
+return msg;`,
     })
     .then('a10012', 'Core.FileSystem.WriteFile', 'Append to Output', {
       inPath: Message('output_path'),

--- a/concatenate-text-files/subflows/a11000.ts
+++ b/concatenate-text-files/subflows/a11000.ts
@@ -3,7 +3,11 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/concatenate-text-files/fixtures'; msg._dl_dir = fixtures; msg._dl_part1_txt = fixtures + '/part1.txt'; msg._dl_part2_txt = fixtures + '/part2.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/concatenate-text-files/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_part1_txt = fixtures + '/part1.txt';
+msg._dl_part2_txt = fixtures + '/part2.txt';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/consolidate-excel-reports/main.ts
+++ b/consolidate-excel-reports/main.ts
@@ -8,7 +8,11 @@ const myFlow = flow.create('7ef0a17b-e4da-4b67-8019-b65f98c6d90f', 'Imported Con
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10002', 'Core.Programming.Function', 'Init Combined', {
-      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/consolidate-excel-reports/fixtures'; msg.fixtures_dir = fixtures; msg.combined_table = null; msg.output_path = fixtures + '/Consolidated Report.csv'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/consolidate-excel-reports/fixtures';
+msg.fixtures_dir = fixtures;
+msg.combined_table = null;
+msg.output_path = fixtures + '/Consolidated Report.csv';
+return msg;`,
     })
     .then('a10020', 'Core.Flow.SubFlow', 'Get Excel Files Details', {})
     .then('a10003', 'Core.Programming.Function', 'Validate List', {
@@ -44,7 +48,9 @@ return msg;`,
       optMode: 'truncate',
     })
     .then('a10031', 'Core.Programming.Function', 'Build Attachments', {
-      func: `msg.attachments = [msg.output_path]; msg.retry_count = 0; return msg;`,
+      func: `msg.attachments = [msg.output_path];
+msg.retry_count = 0;
+return msg;`,
     })
     .then('a10040', 'Core.Flow.GoTo', 'Enter Retry', {
       optNodes: { type: 'goto', ids: ['a10041'], all: false },
@@ -60,7 +66,8 @@ return msg;`,
       replyAllMode: false,
     })
     .then('a10033', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'The consolidated file has been saved in ' + msg.output_path + ' and emailed to ' + msg.recipient_email; return msg;`,
+      func: `msg.dialog_text = 'The consolidated file has been saved in ' + msg.output_path + ' and emailed to ' + msg.recipient_email;
+return msg;`,
     })
     .then('a10034', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('Flow run successful'),
@@ -73,7 +80,8 @@ return msg;`,
   })
     .then('a10051', 'Core.Programming.Function', 'Check Retry', {
       outputs: 2,
-      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1; return [msg, null]; } return [null, msg];`,
+      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1;
+return [msg, null]; } return [null, msg];`,
     });
 
   f.node('a10052', 'Core.Programming.Sleep', 'Wait 5s', {

--- a/consolidate-excel-reports/subflows/a10020.ts
+++ b/consolidate-excel-reports/subflows/a10020.ts
@@ -9,7 +9,9 @@ subflow.create('Get Excel Files Details', (f) => {
       outText: Message('recipient_email'),
     })
     .then('b10003', 'Core.Programming.Function', 'Seed File List', {
-      func: `var fixtures = msg.fixtures_dir || (global.get('$Home$') + '/templates/excel-automation/consolidate-excel-reports/fixtures'); msg.file_list = [fixtures + '/report_q1.csv', fixtures + '/report_q2.csv', fixtures + '/report_q3.csv']; return msg;`,
+      func: `var fixtures = msg.fixtures_dir || (global.get('$Home$') + '/templates/excel-automation/consolidate-excel-reports/fixtures');
+msg.file_list = [fixtures + '/report_q1.csv', fixtures + '/report_q2.csv', fixtures + '/report_q3.csv'];
+return msg;`,
     })
     .then('b10004', 'Core.Flow.End', 'End', { sfPort: 0 });
 });

--- a/consolidate-excel-reports/subflows/a11000.ts
+++ b/consolidate-excel-reports/subflows/a11000.ts
@@ -3,7 +3,15 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/consolidate-excel-reports/fixtures'; msg._dl_dir = fixtures; msg._dl_report_q1_csv = fixtures + '/report_q1.csv'; msg._dl_report_q1_xlsx = fixtures + '/report_q1.xlsx'; msg._dl_report_q2_csv = fixtures + '/report_q2.csv'; msg._dl_report_q2_xlsx = fixtures + '/report_q2.xlsx'; msg._dl_report_q3_csv = fixtures + '/report_q3.csv'; msg._dl_report_q3_xlsx = fixtures + '/report_q3.xlsx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/consolidate-excel-reports/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_report_q1_csv = fixtures + '/report_q1.csv';
+msg._dl_report_q1_xlsx = fixtures + '/report_q1.xlsx';
+msg._dl_report_q2_csv = fixtures + '/report_q2.csv';
+msg._dl_report_q2_xlsx = fixtures + '/report_q2.xlsx';
+msg._dl_report_q3_csv = fixtures + '/report_q3.csv';
+msg._dl_report_q3_xlsx = fixtures + '/report_q3.xlsx';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/convert-datetime-to-text/main.ts
+++ b/convert-datetime-to-text/main.ts
@@ -19,7 +19,8 @@ const myFlow = flow.create('220659bb-c450-4654-af7b-ded057ed7c3b', 'Imported Con
       outFormattedTime: Message('formatted_date_time'),
     })
     .then('a10011', 'Core.Programming.Function', 'Build Short Date Text', {
-      func: `msg.dialog_text = "Current date in 'short date' text format:\\n" + msg.formatted_date_time; return msg;`,
+      func: `msg.dialog_text = "Current date in 'short date' text format:\\n" + msg.formatted_date_time;
+return msg;`,
     })
     .then('a10012', 'Core.Dialog.MessageBox', 'Show Short Date', {
       inTitle: Custom('Result'),
@@ -34,7 +35,8 @@ const myFlow = flow.create('220659bb-c450-4654-af7b-ded057ed7c3b', 'Imported Con
       outFormattedTime: Message('formatted_date_time'),
     })
     .then('a10021', 'Core.Programming.Function', 'Build Short Time Text', {
-      func: `msg.dialog_text = "Current time in 'short time' text format:\\n" + msg.formatted_date_time; return msg;`,
+      func: `msg.dialog_text = "Current time in 'short time' text format:\\n" + msg.formatted_date_time;
+return msg;`,
     })
     .then('a10022', 'Core.Dialog.MessageBox', 'Show Short Time', {
       inTitle: Custom('Result'),
@@ -49,7 +51,8 @@ const myFlow = flow.create('220659bb-c450-4654-af7b-ded057ed7c3b', 'Imported Con
       outFormattedTime: Message('formatted_date_time'),
     })
     .then('a10031', 'Core.Programming.Function', 'Build Long Date Text', {
-      func: `msg.dialog_text = "Current date in 'MMMM dd, yyyy' text format:\\n" + msg.formatted_date_time; return msg;`,
+      func: `msg.dialog_text = "Current date in 'MMMM dd, yyyy' text format:\\n" + msg.formatted_date_time;
+return msg;`,
     })
     .then('a10032', 'Core.Dialog.MessageBox', 'Show Long Date', {
       inTitle: Custom('Result'),
@@ -76,7 +79,8 @@ const myFlow = flow.create('220659bb-c450-4654-af7b-ded057ed7c3b', 'Imported Con
       outFormattedTime: Message('formatted_date_time'),
     })
     .then('a10051', 'Core.Programming.Function', 'Build 12-Hour Time Text', {
-      func: `msg.dialog_text = "Current time in 'hh:mm:ss tt' text format:\\n" + msg.formatted_date_time; return msg;`,
+      func: `msg.dialog_text = "Current time in 'hh:mm:ss tt' text format:\\n" + msg.formatted_date_time;
+return msg;`,
     })
     .then('a10052', 'Core.Dialog.MessageBox', 'Show 12-Hour Time', {
       inTitle: Custom('Result'),
@@ -103,7 +107,8 @@ const myFlow = flow.create('220659bb-c450-4654-af7b-ded057ed7c3b', 'Imported Con
       outFormattedTime: Message('formatted_date_time'),
     })
     .then('a10071', 'Core.Programming.Function', 'Build Full DateTime Text', {
-      func: `msg.dialog_text = "Today's date and time is " + msg.formatted_date_time; return msg;`,
+      func: `msg.dialog_text = "Today's date and time is " + msg.formatted_date_time;
+return msg;`,
     })
     .then('a10072', 'Core.Dialog.MessageBox', 'Show Full DateTime', {
       inTitle: Custom('Result'),

--- a/convert-excel-to-pdf-using-vbscript/main.ts
+++ b/convert-excel-to-pdf-using-vbscript/main.ts
@@ -22,7 +22,11 @@ const myFlow = flow.create('70e36839-1f44-4792-ab5d-06e9c2612969', 'Imported Con
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/scripting/convert-excel-to-pdf-using-vbscript/fixtures'; msg.fixtures_dir = fixtures; msg.sample_xlsx = fixtures + '/sample.xlsx'; msg.output_dir = fixtures + '/output'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/scripting/convert-excel-to-pdf-using-vbscript/fixtures';
+msg.fixtures_dir = fixtures;
+msg.sample_xlsx = fixtures + '/sample.xlsx';
+msg.output_dir = fixtures + '/output';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask Excel', {
       inTitle: Custom('Convert Excel to PDF'),
@@ -38,7 +42,10 @@ const myFlow = flow.create('70e36839-1f44-4792-ab5d-06e9c2612969', 'Imported Con
     })
     .then('a10004', 'Core.Programming.Function', 'Validate', {
       outputs: 2,
-      func: `if (!msg.excel_path || !/\\.xlsx?$/i.test(msg.excel_path) || !msg.destination_folder) return [null, msg]; msg.pdf_path = msg.destination_folder + '/ConvertedPDFfile.pdf'; msg.script_path = msg.destination_folder + '/_convert.vbs'; return [msg, null];`,
+      func: `if (!msg.excel_path || !/\\.xlsx?$/i.test(msg.excel_path) || !msg.destination_folder) return [null, msg];
+msg.pdf_path = msg.destination_folder + '/ConvertedPDFfile.pdf';
+msg.script_path = msg.destination_folder + '/_convert.vbs';
+return [msg, null];`,
     });
 
   f.node('a10005', 'Core.FileSystem.Create', 'Ensure Dest Dir', {
@@ -47,7 +54,9 @@ const myFlow = flow.create('70e36839-1f44-4792-ab5d-06e9c2612969', 'Imported Con
     continueOnError: true,
   })
     .then('a10006', 'Core.Programming.Function', 'Build Script', {
-      func: `var tpl = ${JSON.stringify(scriptTemplate)}; msg.vbs_body = tpl.replace('\${EXCEL_PATH}', '"' + msg.excel_path.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '""') + '"').replace('\${PDF_PATH}', '"' + msg.pdf_path.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '""') + '"'); return msg;`,
+      func: `var tpl = ${JSON.stringify(scriptTemplate)};
+msg.vbs_body = tpl.replace('\${EXCEL_PATH}', '"' + msg.excel_path.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '""') + '"').replace('\${PDF_PATH}', '"' + msg.pdf_path.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '""') + '"');
+return msg;`,
     })
     .then('a10007', 'Core.FileSystem.WriteFile', 'Write VBS', {
       inPath: Message('script_path'),
@@ -56,7 +65,8 @@ const myFlow = flow.create('70e36839-1f44-4792-ab5d-06e9c2612969', 'Imported Con
       optMode: 'truncate',
     })
     .then('a10008', 'Core.Programming.Function', 'Build Args', {
-      func: `msg.vbs_args = ['//Nologo', msg.script_path]; return msg;`,
+      func: `msg.vbs_args = ['//Nologo', msg.script_path];
+return msg;`,
     })
     .then('a10009', 'Core.Process.StartProcess', 'Run VBScript', {
       inFilePath: Custom('cscript'),
@@ -69,7 +79,8 @@ const myFlow = flow.create('70e36839-1f44-4792-ab5d-06e9c2612969', 'Imported Con
       continueOnError: true,
     })
     .then('a10011', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'The generated PDF file is stored at: ' + msg.pdf_path; return msg;`,
+      func: `msg.dialog_text = 'The generated PDF file is stored at: ' + msg.pdf_path;
+return msg;`,
     })
     .then('a10012', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('The flow ran successfully.'),

--- a/convert-excel-to-pdf-using-vbscript/subflows/a11000.ts
+++ b/convert-excel-to-pdf-using-vbscript/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/scripting/convert-excel-to-pdf-using-vbscript/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_xlsx = fixtures + '/sample.xlsx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/scripting/convert-excel-to-pdf-using-vbscript/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_xlsx = fixtures + '/sample.xlsx';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/convert-text-to-datetime/main.ts
+++ b/convert-text-to-datetime/main.ts
@@ -14,7 +14,8 @@ const myFlow = flow.create('ccebdc1e-d95a-4467-976b-62ce4b47cfd2', 'Imported Con
       outFormattedTime: Message('text_as_date_time'),
     })
     .then('a10012', 'Core.Programming.Function', 'Build Date Dialog Text', {
-      func: `msg.dialog_text = "The text '20220101' has been converted to the following datetime variable: " + msg.text_as_date_time; return msg;`,
+      func: `msg.dialog_text = "The text '20220101' has been converted to the following datetime variable: " + msg.text_as_date_time;
+return msg;`,
     })
     .then('a10013', 'Core.Dialog.MessageBox', 'Show Date', {
       inTitle: Custom('Result'),
@@ -29,7 +30,8 @@ const myFlow = flow.create('ccebdc1e-d95a-4467-976b-62ce4b47cfd2', 'Imported Con
       outFormattedTime: Message('text_as_date_time'),
     })
     .then('a10022', 'Core.Programming.Function', 'Build Time Dialog Text', {
-      func: `msg.dialog_text = "The text '23:45:00' has been converted to the following datetime variable: " + msg.text_as_date_time; return msg;`,
+      func: `msg.dialog_text = "The text '23:45:00' has been converted to the following datetime variable: " + msg.text_as_date_time;
+return msg;`,
     })
     .then('a10023', 'Core.Dialog.MessageBox', 'Show Time', {
       inTitle: Custom('Result'),
@@ -44,7 +46,8 @@ const myFlow = flow.create('ccebdc1e-d95a-4467-976b-62ce4b47cfd2', 'Imported Con
       outFormattedTime: Message('text_as_date_time'),
     })
     .then('a10032', 'Core.Programming.Function', 'Build DateTime Dialog Text', {
-      func: `msg.dialog_text = "The text 'January 01, 2022 23:45:00' has been converted to the following datetime variable: " + msg.text_as_date_time; return msg;`,
+      func: `msg.dialog_text = "The text 'January 01, 2022 23:45:00' has been converted to the following datetime variable: " + msg.text_as_date_time;
+return msg;`,
     })
     .then('a10033', 'Core.Dialog.MessageBox', 'Show DateTime', {
       inTitle: Custom('Result'),

--- a/copy-files/main.ts
+++ b/copy-files/main.ts
@@ -6,7 +6,11 @@ const myFlow = flow.create('f16e8944-9f01-4fe0-b787-23b3d543f62c', 'Imported Cop
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10002', 'Core.Programming.Function', 'Seed Sources', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/copy-files/fixtures'; msg.fixtures_dir = fixtures; msg.files_to_copy = [fixtures + '/source_a.txt', fixtures + '/source_b.txt']; msg.default_dest = fixtures + '/dest'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/copy-files/fixtures';
+msg.fixtures_dir = fixtures;
+msg.files_to_copy = [fixtures + '/source_a.txt', fixtures + '/source_b.txt'];
+msg.default_dest = fixtures + '/dest';
+return msg;`,
     })
     .then('a10003', 'Core.Dialog.InputBox', 'Ask Destination Folder', {
       inTitle: Custom('Copy files'),
@@ -36,7 +40,10 @@ const myFlow = flow.create('f16e8944-9f01-4fe0-b787-23b3d543f62c', 'Imported Cop
     });
 
   f.node('a10012', 'Core.Programming.Function', 'Build Dest Path', {
-    func: `var p = msg.current_file; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); msg.dest_path = msg.destination_folder + '/' + p.substring(lastSlash + 1); return msg;`,
+    func: `var p = msg.current_file;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+msg.dest_path = msg.destination_folder + '/' + p.substring(lastSlash + 1);
+return msg;`,
   })
     .then('a10013', 'Core.FileSystem.Copy', 'Copy File', {
       inSrcPath: Message('current_file'),

--- a/copy-files/subflows/a11000.ts
+++ b/copy-files/subflows/a11000.ts
@@ -3,7 +3,11 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/copy-files/fixtures'; msg._dl_dir = fixtures; msg._dl_source_a_txt = fixtures + '/source_a.txt'; msg._dl_source_b_txt = fixtures + '/source_b.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/copy-files/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_source_a_txt = fixtures + '/source_a.txt';
+msg._dl_source_b_txt = fixtures + '/source_b.txt';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/count-lines-of-text-file/main.ts
+++ b/count-lines-of-text-file/main.ts
@@ -6,7 +6,9 @@ const myFlow = flow.create('681e3719-b6fc-4a07-bc58-050b30229b0b', 'Imported Cou
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Build Default Path', {
-      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/count-lines-of-text-file/fixtures'; msg.fixture_path = fixtures + '/sample.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/count-lines-of-text-file/fixtures';
+msg.fixture_path = fixtures + '/sample.txt';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.MessageBox', 'Show Description', {
       inTitle: Custom('Description'),
@@ -23,7 +25,8 @@ const myFlow = flow.create('681e3719-b6fc-4a07-bc58-050b30229b0b', 'Imported Cou
     })
     .then('a10004', 'Core.Programming.Function', 'Branch On Selection', {
       outputs: 2,
-      func: `var p = (msg.selected_text_file || '').trim(); return (p && /\\.txt$/i.test(p)) ? [msg, null] : [null, msg];`,
+      func: `var p = (msg.selected_text_file || '').trim();
+return (p && /\\.txt$/i.test(p)) ? [msg, null] : [null, msg];`,
     });
 
   f.node('a10005', 'Core.FileSystem.ReadFile', 'Read File', {
@@ -32,7 +35,12 @@ const myFlow = flow.create('681e3719-b6fc-4a07-bc58-050b30229b0b', 'Imported Cou
     outContent: Message('file_contents'),
   })
     .then('a10006', 'Core.Programming.Function', 'Count Lines', {
-      func: `var lf = String.fromCharCode(10); var lines = msg.file_contents.split(lf); if (lines.length && lines[lines.length - 1] === '') lines.pop(); msg.line_count = lines.length; msg.dialog_text = 'The file has ' + msg.line_count + ' lines!'; return msg;`,
+      func: `var lf = String.fromCharCode(10);
+var lines = msg.file_contents.split(lf);
+if (lines.length && lines[lines.length - 1] === '') lines.pop();
+msg.line_count = lines.length;
+msg.dialog_text = 'The file has ' + msg.line_count + ' lines!';
+return msg;`,
     })
     .then('a10007', 'Core.Dialog.MessageBox', 'Show Line Count', {
       inTitle: Custom('Results...'),

--- a/count-lines-of-text-file/subflows/a11000.ts
+++ b/count-lines-of-text-file/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/count-lines-of-text-file/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_txt = fixtures + '/sample.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/count-lines-of-text-file/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_txt = fixtures + '/sample.txt';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/create-pdf-from-selected-pages/main.ts
+++ b/create-pdf-from-selected-pages/main.ts
@@ -8,7 +8,10 @@ const myFlow = flow.create('200f475c-9ece-4120-8df2-235489362bbc', 'Imported Cre
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10020', 'Core.Programming.Function', 'Build Defaults', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/create-pdf-from-selected-pages/fixtures'; msg.default_pdf = fixtures + '/sample.pdf'; msg.default_dest = fixtures + '/output'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/create-pdf-from-selected-pages/fixtures';
+msg.default_pdf = fixtures + '/sample.pdf';
+msg.default_dest = fixtures + '/output';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask PDF', {
       inTitle: Custom('Create new PDF from selected PDF pages'),
@@ -30,7 +33,25 @@ const myFlow = flow.create('200f475c-9ece-4120-8df2-235489362bbc', 'Imported Cre
     })
     .then('a10005', 'Core.Programming.Function', 'Validate And Parse', {
       outputs: 2,
-      func: `if (!msg.pdf_path || !/\\.pdf$/i.test(msg.pdf_path) || !msg.destination_folder) return [null, msg]; var pageSet = []; var groups = String(msg.pages_text || '').split(','); for (var i = 0; i < groups.length; i++) { var g = groups[i].trim(); if (!g) continue; var m = g.match(/^(\\d+)-(\\d+)$/); if (m) { var a = Number(m[1]), b = Number(m[2]); for (var j = a; j <= b; j++) pageSet.push(j); } else if (/^\\d+$/.test(g)) { pageSet.push(Number(g)); } } pageSet = pageSet.filter(function (x, idx, arr) { return arr.indexOf(x) === idx; }); pageSet.sort(function (a, b) { return a - b; }); if (!pageSet.length) return [null, msg]; msg.selected_pages = pageSet; var p = msg.pdf_path; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); msg.pages_dir = p.substring(0, lastSlash) + '/_pages'; msg.suffix_base = 'NewPDFfile'; msg.suffix_ext = '.pdf'; msg.suffix_idx = 0; msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + msg.suffix_ext; return [msg, null];`,
+      func: `if (!msg.pdf_path || !/\\.pdf$/i.test(msg.pdf_path) || !msg.destination_folder) return [null, msg];
+var pageSet = [];
+var groups = String(msg.pages_text || '').split(',');
+for (var i = 0; i < groups.length; i++) { var g = groups[i].trim();
+if (!g) continue;
+var m = g.match(/^(\\d+)-(\\d+)$/);
+if (m) { var a = Number(m[1]), b = Number(m[2]);
+for (var j = a; j <= b; j++) pageSet.push(j); } else if (/^\\d+$/.test(g)) { pageSet.push(Number(g)); } } pageSet = pageSet.filter(function (x, idx, arr) { return arr.indexOf(x) === idx; });
+pageSet.sort(function (a, b) { return a - b; });
+if (!pageSet.length) return [null, msg];
+msg.selected_pages = pageSet;
+var p = msg.pdf_path;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+msg.pages_dir = p.substring(0, lastSlash) + '/_pages';
+msg.suffix_base = 'NewPDFfile';
+msg.suffix_ext = '.pdf';
+msg.suffix_idx = 0;
+msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + msg.suffix_ext;
+return [msg, null];`,
     });
 
   f.node('a10006', 'Core.FileSystem.Create', 'Ensure Dest Dir', {
@@ -63,7 +84,14 @@ const myFlow = flow.create('200f475c-9ece-4120-8df2-235489362bbc', 'Imported Cre
     })
     .then('a10010', 'Core.Programming.Function', 'Pick Selected Paths', {
       outputs: 2,
-      func: `var list = (msg.page_files || []).filter(function (x) { return !x.IsDir; }); list.sort(function (a, b) { return a.Name < b.Name ? -1 : (a.Name > b.Name ? 1 : 0); }); var paths = list.map(function (x) { return x.Name; }); var picked = []; for (var i = 0; i < msg.selected_pages.length; i++) { var n = msg.selected_pages[i]; if (n >= 1 && n <= paths.length) picked.push(paths[n - 1]); } if (!picked.length) return [null, msg]; msg.picked_paths = picked; return [msg, null];`,
+      func: `var list = (msg.page_files || []).filter(function (x) { return !x.IsDir; });
+list.sort(function (a, b) { return a.Name < b.Name ? -1 : (a.Name > b.Name ? 1 : 0); });
+var paths = list.map(function (x) { return x.Name; });
+var picked = [];
+for (var i = 0; i < msg.selected_pages.length; i++) { var n = msg.selected_pages[i];
+if (n >= 1 && n <= paths.length) picked.push(paths[n - 1]); } if (!picked.length) return [null, msg];
+msg.picked_paths = picked;
+return [msg, null];`,
     })
     .then('a10030', 'Core.Flow.GoTo', 'Enter Suffix Loop', {
       optNodes: { type: 'goto', ids: ['a10031'], all: false },
@@ -76,7 +104,10 @@ const myFlow = flow.create('200f475c-9ece-4120-8df2-235489362bbc', 'Imported Cre
     })
     .then('a10033', 'Core.Programming.Function', 'Next Or Done', {
       outputs: 2,
-      func: `if (msg.candidate_exists) { msg.suffix_idx += 1; msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + '_' + (msg.suffix_idx + 1) + msg.suffix_ext; return [msg, null]; } msg.output_path = msg.candidate_path; return [null, msg];`,
+      func: `if (msg.candidate_exists) { msg.suffix_idx += 1;
+msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + '_' + (msg.suffix_idx + 1) + msg.suffix_ext;
+return [msg, null]; } msg.output_path = msg.candidate_path;
+return [null, msg];`,
     });
 
   f.node('a10034', 'Core.Flow.GoTo', 'Loop Back', {
@@ -92,7 +123,8 @@ const myFlow = flow.create('200f475c-9ece-4120-8df2-235489362bbc', 'Imported Cre
       continueOnError: true,
     })
     .then('a10013', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'The new file has been saved in: ' + msg.output_path; return msg;`,
+      func: `msg.dialog_text = 'The new file has been saved in: ' + msg.output_path;
+return msg;`,
     })
     .then('a10014', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('Done!'),

--- a/create-pdf-from-selected-pages/subflows/a11000.ts
+++ b/create-pdf-from-selected-pages/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/create-pdf-from-selected-pages/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_pdf = fixtures + '/sample.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/create-pdf-from-selected-pages/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_pdf = fixtures + '/sample.pdf';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/days-of-your-life/main.ts
+++ b/days-of-your-life/main.ts
@@ -38,10 +38,12 @@ const myFlow = flow.create('2762c4f4-e834-4d3b-945c-60d907406d89', 'Imported Day
       outSpan: Message('span_ms'),
     })
     .then('a10007', 'Core.Programming.Function', 'Milliseconds to Days', {
-      func: `msg.days_alive = Math.floor(msg.span_ms / 86400000); return msg;`,
+      func: `msg.days_alive = Math.floor(msg.span_ms / 86400000);
+return msg;`,
     })
     .then('a10008', 'Core.Programming.Function', 'Build Dialog Text', {
-      func: `msg.dialog_text = "Today is day #" + msg.days_alive + "\\n\\nEach day is unique. Make the most of it and don't forget to laugh!!!"; return msg;`,
+      func: `msg.dialog_text = "Today is day #" + msg.days_alive + "\\n\\nEach day is unique. Make the most of it and don't forget to laugh!!!";
+return msg;`,
     })
     .then('a10009', 'Core.Dialog.MessageBox', 'Show Age', {
       inTitle: Custom('Attention!'),

--- a/delete-files-of-specific-size-range/main.ts
+++ b/delete-files-of-specific-size-range/main.ts
@@ -6,7 +6,12 @@ const myFlow = flow.create('bfd491c1-40ac-4c16-838b-d48add842b43', 'Imported Del
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Seed Sources', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/delete-files-of-specific-size-range/fixtures'; msg.fixtures_dir = fixtures; msg.small_path = fixtures + '/small.txt'; msg.medium_path = fixtures + '/medium.txt'; msg.large_path = fixtures + '/large.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/delete-files-of-specific-size-range/fixtures';
+msg.fixtures_dir = fixtures;
+msg.small_path = fixtures + '/small.txt';
+msg.medium_path = fixtures + '/medium.txt';
+msg.large_path = fixtures + '/large.txt';
+return msg;`,
     })
     .then('a10002', 'Core.FileSystem.WriteFile', 'Seed Small File', {
       inPath: Message('small_path'),
@@ -46,7 +51,10 @@ const myFlow = flow.create('bfd491c1-40ac-4c16-838b-d48add842b43', 'Imported Del
     })
     .then('a10008', 'Core.Programming.Function', 'Parse Inputs', {
       outputs: 2,
-      func: `msg.minimum_size = Number(msg.min_size_text); msg.maximum_size = Number(msg.max_size_text); if (!msg.selected_folder || isNaN(msg.minimum_size) || isNaN(msg.maximum_size)) return [null, msg]; return [msg, null];`,
+      func: `msg.minimum_size = Number(msg.min_size_text);
+msg.maximum_size = Number(msg.max_size_text);
+if (!msg.selected_folder || isNaN(msg.minimum_size) || isNaN(msg.maximum_size)) return [null, msg];
+return [msg, null];`,
     });
 
   f.node('a10009', 'Core.FileSystem.List', 'List Folder', {
@@ -69,11 +77,15 @@ const myFlow = flow.create('bfd491c1-40ac-4c16-838b-d48add842b43', 'Imported Del
 
   f.node('a10022', 'Core.Programming.Function', 'Size Range Check', {
     outputs: 2,
-    func: `var f = msg.current_file || {}; if (f.IsDir) return [null, msg]; var kb = Number(f.Size) / 1024; return (kb >= msg.minimum_size && kb <= msg.maximum_size) ? [msg, null] : [null, msg];`,
+    func: `var f = msg.current_file || {};
+if (f.IsDir) return [null, msg];
+var kb = Number(f.Size) / 1024;
+return (kb >= msg.minimum_size && kb <= msg.maximum_size) ? [msg, null] : [null, msg];`,
   });
 
   f.node('a10023', 'Core.Programming.Function', 'Build Target Path', {
-    func: `msg.file_to_delete = msg.current_file.Name; return msg;`,
+    func: `msg.file_to_delete = msg.current_file.Name;
+return msg;`,
   })
     .then('a10026', 'Core.FileSystem.Delete', 'Delete In-Range File', {
       inPath: Message('file_to_delete'),

--- a/delete-files-of-specific-size-range/subflows/a11000.ts
+++ b/delete-files-of-specific-size-range/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/delete-files-of-specific-size-range/fixtures'; msg._dl_dir = fixtures; msg._dl_seed_txt = fixtures + '/seed.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/delete-files-of-specific-size-range/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_seed_txt = fixtures + '/seed.txt';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/display-javascript-output/main.ts
+++ b/display-javascript-output/main.ts
@@ -11,7 +11,10 @@ const myFlow = flow.create('9c1b90e6-2b25-4775-ace0-8f37ebb86e64', 'Imported Dis
       outStdout: Message('javascript_output'),
     })
     .then('a10003', 'Core.Programming.Function', 'Trim Output', {
-      func: `var s = String(msg.javascript_output || ''); while (s.length && (s.charCodeAt(s.length - 1) === 10 || s.charCodeAt(s.length - 1) === 13)) s = s.slice(0, -1); msg.javascript_output = s; return msg;`,
+      func: `var s = String(msg.javascript_output || '');
+while (s.length && (s.charCodeAt(s.length - 1) === 10 || s.charCodeAt(s.length - 1) === 13)) s = s.slice(0, -1);
+msg.javascript_output = s;
+return msg;`,
     })
     .then('a10004', 'Core.Dialog.MessageBox', 'Show Output', {
       inTitle: Custom('Output from JavaScript:'),

--- a/display-powershell-output/main.ts
+++ b/display-powershell-output/main.ts
@@ -11,7 +11,10 @@ const myFlow = flow.create('3e677d4f-f651-41f3-a2f4-0f40ffd9bb97', 'Imported Dis
       outStdout: Message('powershell_output'),
     })
     .then('a10003', 'Core.Programming.Function', 'Trim Output', {
-      func: `var s = String(msg.powershell_output || ''); while (s.length && (s.charCodeAt(s.length - 1) === 10 || s.charCodeAt(s.length - 1) === 13)) s = s.slice(0, -1); msg.powershell_output = s; return msg;`,
+      func: `var s = String(msg.powershell_output || '');
+while (s.length && (s.charCodeAt(s.length - 1) === 10 || s.charCodeAt(s.length - 1) === 13)) s = s.slice(0, -1);
+msg.powershell_output = s;
+return msg;`,
     })
     .then('a10004', 'Core.Dialog.MessageBox', 'Show Output', {
       inTitle: Custom('Output from PowerShell script:'),

--- a/display-python-output/main.ts
+++ b/display-python-output/main.ts
@@ -11,7 +11,10 @@ const myFlow = flow.create('a183bd73-0e54-4c72-b689-716eb3835e15', 'Imported Dis
       outStdout: Message('python_output'),
     })
     .then('a10003', 'Core.Programming.Function', 'Trim Output', {
-      func: `var s = String(msg.python_output || ''); while (s.length && (s.charCodeAt(s.length - 1) === 10 || s.charCodeAt(s.length - 1) === 13)) s = s.slice(0, -1); msg.python_output = s; return msg;`,
+      func: `var s = String(msg.python_output || '');
+while (s.length && (s.charCodeAt(s.length - 1) === 10 || s.charCodeAt(s.length - 1) === 13)) s = s.slice(0, -1);
+msg.python_output = s;
+return msg;`,
     })
     .then('a10004', 'Core.Dialog.MessageBox', 'Show Output', {
       inTitle: Custom('Output from Python script:'),

--- a/display-vbscript-output/main.ts
+++ b/display-vbscript-output/main.ts
@@ -12,7 +12,11 @@ const myFlow = flow.create('859c38a1-c104-4dc2-b547-8b271b497584', 'Imported Dis
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10002', 'Core.Programming.Function', 'Build Script', {
-      func: `msg.vbs_script = ${JSON.stringify(inlineVbscript)}; var tmp = global.get('$TempDir$') || 'C:/Windows/Temp'; msg.vbs_path = tmp + '/robomotion_inline_' + Date.now() + '.vbs'; msg.vbs_args = ['//Nologo', msg.vbs_path]; return msg;`,
+      func: `msg.vbs_script = ${JSON.stringify(inlineVbscript)};
+var tmp = global.get('$TempDir$') || 'C:/Windows/Temp';
+msg.vbs_path = tmp + '/robomotion_inline_' + Date.now() + '.vbs';
+msg.vbs_args = ['//Nologo', msg.vbs_path];
+return msg;`,
     })
     .then('a10003', 'Core.FileSystem.WriteFile', 'Write Temp VBS', {
       inPath: Message('vbs_path'),
@@ -31,7 +35,10 @@ const myFlow = flow.create('859c38a1-c104-4dc2-b547-8b271b497584', 'Imported Dis
       continueOnError: true,
     })
     .then('a10006', 'Core.Programming.Function', 'Trim Output', {
-      func: `var s = String(msg.vbscript_output || ''); while (s.length && (s.charCodeAt(s.length - 1) === 10 || s.charCodeAt(s.length - 1) === 13)) s = s.slice(0, -1); msg.vbscript_output = s; return msg;`,
+      func: `var s = String(msg.vbscript_output || '');
+while (s.length && (s.charCodeAt(s.length - 1) === 10 || s.charCodeAt(s.length - 1) === 13)) s = s.slice(0, -1);
+msg.vbscript_output = s;
+return msg;`,
     })
     .then('a10007', 'Core.Dialog.MessageBox', 'Show Output', {
       inTitle: Custom('Output from VBScript:'),

--- a/display-vbscript-output/subflows/a11000.ts
+++ b/display-vbscript-output/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/scripting/display-vbscript-output/fixtures'; msg._dl_dir = fixtures; msg._dl_hello_vbs = fixtures + '/hello.vbs'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/scripting/display-vbscript-output/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_hello_vbs = fixtures + '/hello.vbs';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/extract-phone-numbers-and-emails/main.ts
+++ b/extract-phone-numbers-and-emails/main.ts
@@ -18,10 +18,17 @@ const myFlow = flow.create('fd197349-8ff0-4205-b6c5-ae440d8ea644', 'Imported Ext
     });
 
   f.node('a10004', 'Core.Programming.Function', 'Extract Entities', {
-    func: `var emailRe = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}/g; var phoneRe = /\\+?\\d[\\d\\s().-]{7,}\\d/g; msg.recognized_emails = msg.input_text.match(emailRe) || []; msg.recognized_phone_numbers = msg.input_text.match(phoneRe) || []; if (!msg.recognized_phone_numbers.length) msg.recognized_phone_numbers = ['No phone number found in the given text. ']; if (!msg.recognized_emails.length) msg.recognized_emails = ['No email found in the given text. ']; return msg;`,
+    func: `var emailRe = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}/g;
+var phoneRe = /\\+?\\d[\\d\\s().-]{7,}\\d/g;
+msg.recognized_emails = msg.input_text.match(emailRe) || [];
+msg.recognized_phone_numbers = msg.input_text.match(phoneRe) || [];
+if (!msg.recognized_phone_numbers.length) msg.recognized_phone_numbers = ['No phone number found in the given text. '];
+if (!msg.recognized_emails.length) msg.recognized_emails = ['No email found in the given text. '];
+return msg;`,
   })
     .then('a10005', 'Core.Programming.Function', 'Build Results Text', {
-      func: `msg.dialog_text = 'Recognized phone number(s):\\n' + msg.recognized_phone_numbers.join(', ') + '\\n\\nRecognized email(s):\\n' + msg.recognized_emails.join(', '); return msg;`,
+      func: `msg.dialog_text = 'Recognized phone number(s):\\n' + msg.recognized_phone_numbers.join(', ') + '\\n\\nRecognized email(s):\\n' + msg.recognized_emails.join(', ');
+return msg;`,
     })
     .then('a10006', 'Core.Dialog.MessageBox', 'Show Results', {
       inTitle: Custom('Flow ran succesfully...'),

--- a/extract-tables-from-pdf/main.ts
+++ b/extract-tables-from-pdf/main.ts
@@ -41,7 +41,10 @@ const myFlow = flow.create('e9375004-4206-4251-b855-d97fbb09c729', 'Imported Ext
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/extract-tables-from-pdf/fixtures'; msg.fixtures_dir = fixtures; msg.sample_pdf = fixtures + '/tables.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/extract-tables-from-pdf/fixtures';
+msg.fixtures_dir = fixtures;
+msg.sample_pdf = fixtures + '/tables.pdf';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask PDF', {
       inTitle: Custom('Extract PDF tables to Excel'),
@@ -51,7 +54,16 @@ const myFlow = flow.create('e9375004-4206-4251-b855-d97fbb09c729', 'Imported Ext
     })
     .then('a10003', 'Core.Programming.Function', 'Validate', {
       outputs: 2,
-      func: `if (!msg.pdf_path || !/\\.pdf$/i.test(msg.pdf_path)) return [null, msg]; var p = msg.pdf_path; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); var dir = p.substring(0, lastSlash); var stem = p.substring(lastSlash + 1).replace(/\\.pdf$/i, ''); msg.xlsx_path = dir + '/' + stem + '_tables.xlsx'; var stamp = Date.now(); msg.tables_json_path = dir + '/_tables_' + stamp + '.json'; msg.ps_script_path = dir + '/_write_xlsx_' + stamp + '.ps1'; return [msg, null];`,
+      func: `if (!msg.pdf_path || !/\\.pdf$/i.test(msg.pdf_path)) return [null, msg];
+var p = msg.pdf_path;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+var dir = p.substring(0, lastSlash);
+var stem = p.substring(lastSlash + 1).replace(/\\.pdf$/i, '');
+msg.xlsx_path = dir + '/' + stem + '_tables.xlsx';
+var stamp = Date.now();
+msg.tables_json_path = dir + '/_tables_' + stamp + '.json';
+msg.ps_script_path = dir + '/_write_xlsx_' + stamp + '.ps1';
+return [msg, null];`,
     });
 
   f.node('a10004', 'Robomotion.Pandas.PdfToDataTable', 'Extract Tables', {
@@ -61,7 +73,9 @@ const myFlow = flow.create('e9375004-4206-4251-b855-d97fbb09c729', 'Imported Ext
     outTable: Message('table_list'),
   })
     .then('a10005', 'Core.Programming.Function', 'Serialize Tables JSON', {
-      func: `msg.tables_json = JSON.stringify(msg.table_list || []); msg.ps_script = ${JSON.stringify(psScript)}; return msg;`,
+      func: `msg.tables_json = JSON.stringify(msg.table_list || []);
+msg.ps_script = ${JSON.stringify(psScript)};
+return msg;`,
     })
     .then('a10006', 'Core.FileSystem.WriteFile', 'Write Tables JSON', {
       inPath: Message('tables_json_path'),
@@ -76,7 +90,8 @@ const myFlow = flow.create('e9375004-4206-4251-b855-d97fbb09c729', 'Imported Ext
       optMode: 'truncate',
     })
     .then('a10008', 'Core.Programming.Function', 'Build PS Args', {
-      func: `msg.ps_args = ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', msg.ps_script_path, '-JsonPath', msg.tables_json_path, '-XlsxPath', msg.xlsx_path]; return msg;`,
+      func: `msg.ps_args = ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', msg.ps_script_path, '-JsonPath', msg.tables_json_path, '-XlsxPath', msg.xlsx_path];
+return msg;`,
     })
     .then('a10009', 'Core.Process.StartProcess', 'Run PowerShell', {
       inFilePath: Custom('powershell'),
@@ -92,7 +107,8 @@ const myFlow = flow.create('e9375004-4206-4251-b855-d97fbb09c729', 'Imported Ext
       continueOnError: true,
     })
     .then('a10012', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'Extracted tables saved in: ' + msg.xlsx_path; return msg;`,
+      func: `msg.dialog_text = 'Extracted tables saved in: ' + msg.xlsx_path;
+return msg;`,
     })
     .then('a10013', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('Done!'),

--- a/extract-tables-from-pdf/subflows/a11000.ts
+++ b/extract-tables-from-pdf/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/extract-tables-from-pdf/fixtures'; msg._dl_dir = fixtures; msg._dl_tables_pdf = fixtures + '/tables.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/extract-tables-from-pdf/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_tables_pdf = fixtures + '/tables.pdf';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/extract-text-from-word-document/main.ts
+++ b/extract-text-from-word-document/main.ts
@@ -30,7 +30,10 @@ const myFlow = flow.create('13ddd484-1a0a-4ef2-b3d0-b71f6c0ae7da', 'Imported Ext
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Build Default Path', {
-      func: `var fixtures = global.get('$Home$') + '/templates/scripting/extract-text-from-word-document/fixtures'; msg.fixtures_dir = fixtures; msg.sample_docx = fixtures + '/sample.docx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/scripting/extract-text-from-word-document/fixtures';
+msg.fixtures_dir = fixtures;
+msg.sample_docx = fixtures + '/sample.docx';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask Document', {
       inTitle: Custom('Extract text from Word document'),
@@ -40,11 +43,16 @@ const myFlow = flow.create('13ddd484-1a0a-4ef2-b3d0-b71f6c0ae7da', 'Imported Ext
     })
     .then('a10003', 'Core.Programming.Function', 'Validate', {
       outputs: 2,
-      func: `if (!msg.word_doc_path || !/\\.docx?$/i.test(msg.word_doc_path)) return [null, msg]; var p = msg.word_doc_path; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); msg.script_path = p.substring(0, lastSlash) + '/_extract.vbs'; return [msg, null];`,
+      func: `if (!msg.word_doc_path || !/\\.docx?$/i.test(msg.word_doc_path)) return [null, msg];
+var p = msg.word_doc_path;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+msg.script_path = p.substring(0, lastSlash) + '/_extract.vbs';
+return [msg, null];`,
     });
 
   f.node('a10004', 'Core.Programming.Function', 'Build Script', {
-    func: `var tpl = ${JSON.stringify(scriptTemplate)}; msg.vbs_body = tpl.replace('\${WORD_PATH}', '"' + msg.word_doc_path.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '""') + '"'); return msg;`,
+    func: `var tpl = ${JSON.stringify(scriptTemplate)};
+msg.vbs_body = tpl.replace('\${WORD_PATH}', '"' + msg.word_doc_path.replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '""') + '"'); return msg;`,
   })
     .then('a10005', 'Core.FileSystem.WriteFile', 'Write VBS', {
       inPath: Message('script_path'),
@@ -53,7 +61,8 @@ const myFlow = flow.create('13ddd484-1a0a-4ef2-b3d0-b71f6c0ae7da', 'Imported Ext
       optMode: 'truncate',
     })
     .then('a10006', 'Core.Programming.Function', 'Build Args', {
-      func: `msg.vbs_args = ['//Nologo', msg.script_path]; return msg;`,
+      func: `msg.vbs_args = ['//Nologo', msg.script_path];
+return msg;`,
     })
     .then('a10007', 'Core.Process.StartProcess', 'Run VBScript', {
       inFilePath: Custom('cscript'),
@@ -66,7 +75,13 @@ const myFlow = flow.create('13ddd484-1a0a-4ef2-b3d0-b71f6c0ae7da', 'Imported Ext
       continueOnError: true,
     })
     .then('a10009', 'Core.Programming.Function', 'Trim Output', {
-      func: `var s = String(msg.vbs_output || ''); var start = 0; var end = s.length; while (start < end && (s.charCodeAt(start) === 10 || s.charCodeAt(start) === 13 || s.charCodeAt(start) === 32 || s.charCodeAt(start) === 9)) start++; while (end > start && (s.charCodeAt(end - 1) === 10 || s.charCodeAt(end - 1) === 13 || s.charCodeAt(end - 1) === 32 || s.charCodeAt(end - 1) === 9)) end--; msg.trimmed_text = s.substring(start, end); return msg;`,
+      func: `var s = String(msg.vbs_output || '');
+var start = 0;
+var end = s.length;
+while (start < end && (s.charCodeAt(start) === 10 || s.charCodeAt(start) === 13 || s.charCodeAt(start) === 32 || s.charCodeAt(start) === 9)) start++;
+while (end > start && (s.charCodeAt(end - 1) === 10 || s.charCodeAt(end - 1) === 13 || s.charCodeAt(end - 1) === 32 || s.charCodeAt(end - 1) === 9)) end--;
+msg.trimmed_text = s.substring(start, end);
+return msg;`,
     })
     .then('a10010', 'Core.Dialog.MessageBox', 'Show Output', {
       inTitle: Custom('Extracted text:'),

--- a/extract-text-from-word-document/subflows/a11000.ts
+++ b/extract-text-from-word-document/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/scripting/extract-text-from-word-document/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_docx = fixtures + '/sample.docx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/scripting/extract-text-from-word-document/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_docx = fixtures + '/sample.docx';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/find-and-delete-empty-files/main.ts
+++ b/find-and-delete-empty-files/main.ts
@@ -6,7 +6,11 @@ const myFlow = flow.create('ab2e1663-2766-4215-b465-3e1c1a2fd4e9', 'Imported Fin
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Seed Sources', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/find-and-delete-empty-files/fixtures'; msg.fixtures_dir = fixtures; msg.empty_one_path = fixtures + '/empty_one.txt'; msg.empty_two_path = fixtures + '/empty_two.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/find-and-delete-empty-files/fixtures';
+msg.fixtures_dir = fixtures;
+msg.empty_one_path = fixtures + '/empty_one.txt';
+msg.empty_two_path = fixtures + '/empty_two.txt';
+return msg;`,
     })
     .then('a10002', 'Core.FileSystem.Create', 'Seed Empty File 1', {
       inPath: Message('empty_one_path'),
@@ -49,11 +53,13 @@ const myFlow = flow.create('ab2e1663-2766-4215-b465-3e1c1a2fd4e9', 'Imported Fin
 
   f.node('a10012', 'Core.Programming.Function', 'Zero-Size Check', {
     outputs: 2,
-    func: `var f = msg.current_file || {}; return (!f.IsDir && Number(f.Size) === 0) ? [msg, null] : [null, msg];`,
+    func: `var f = msg.current_file || {};
+return (!f.IsDir && Number(f.Size) === 0) ? [msg, null] : [null, msg];`,
   });
 
   f.node('a10013', 'Core.Programming.Function', 'Build File Path', {
-    func: `msg.file_to_delete = msg.current_file.Name; return msg;`,
+    func: `msg.file_to_delete = msg.current_file.Name;
+return msg;`,
   })
     .then('a10014', 'Core.FileSystem.Delete', 'Delete Empty File', {
       inPath: Message('file_to_delete'),

--- a/find-and-delete-empty-files/subflows/a11000.ts
+++ b/find-and-delete-empty-files/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/find-and-delete-empty-files/fixtures'; msg._dl_dir = fixtures; msg._dl_seed_txt = fixtures + '/seed.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/find-and-delete-empty-files/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_seed_txt = fixtures + '/seed.txt';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/get-current-time/main.ts
+++ b/get-current-time/main.ts
@@ -19,7 +19,8 @@ const myFlow = flow.create('3095c176-9538-487a-92a4-94970eb8d1e5', 'Imported Get
       outFormattedTime: Message('long_time'),
     })
     .then('a10004', 'Core.Programming.Function', 'Build Dialog Text', {
-      func: `msg.dialog_text = 'It is ' + msg.long_time + ' currently.'; return msg;`,
+      func: `msg.dialog_text = 'It is ' + msg.long_time + ' currently.';
+return msg;`,
     })
     .then('a10005', 'Core.Dialog.MessageBox', 'Show Information Dialog', {
       inTitle: Custom('Time right now'),

--- a/get-first-working-day-of-next-month/main.ts
+++ b/get-first-working-day-of-next-month/main.ts
@@ -12,7 +12,9 @@ const myFlow = flow.create('24dd9cda-446f-42e7-8729-3b9e0f3f2244', 'Imported Get
       outNow: Message('now'),
     })
     .then('a10003', 'Core.Programming.Function', 'Compute First Of Next Month', {
-      func: `var d = new Date(msg.now); msg.first_day_of_next_month = new Date(d.getFullYear(), d.getMonth() + 1, 1, 0, 0, 1).toISOString(); return msg;`,
+      func: `var d = new Date(msg.now);
+msg.first_day_of_next_month = new Date(d.getFullYear(), d.getMonth() + 1, 1, 0, 0, 1).toISOString();
+return msg;`,
     })
     .then('a10004', 'Robomotion.DateTime.Split', 'Split First Day', {
       inTime: Message('first_day_of_next_month'),
@@ -21,7 +23,8 @@ const myFlow = flow.create('24dd9cda-446f-42e7-8729-3b9e0f3f2244', 'Imported Get
     })
     .then('a10005', 'Core.Programming.Function', 'Branch Weekend vs Weekday', {
       outputs: 2,
-      func: `msg.day_of_week = String(msg.first_parts.weekday); return msg.day_of_week.charAt(0).toUpperCase() === 'S' ? [msg, null] : [null, msg];`,
+      func: `msg.day_of_week = String(msg.first_parts.weekday);
+return msg.day_of_week.charAt(0).toUpperCase() === 'S' ? [msg, null] : [null, msg];`,
     });
 
   f.node('a10006', 'Core.Dialog.MessageBox', 'Show Weekend Result', {
@@ -32,7 +35,8 @@ const myFlow = flow.create('24dd9cda-446f-42e7-8729-3b9e0f3f2244', 'Imported Get
     .then('a10099', 'Core.Flow.Stop', 'Stop', {});
 
   f.node('a10007', 'Core.Programming.Function', 'Build Weekday Text', {
-    func: `msg.dialog_text = 'First working day of next month is ' + msg.day_of_week; return msg;`,
+    func: `msg.dialog_text = 'First working day of next month is ' + msg.day_of_week;
+return msg;`,
   })
     .then('a10008', 'Core.Dialog.MessageBox', 'Show Weekday Result', {
       inTitle: Custom('Working day info'),

--- a/get-images-from-pdf/main.ts
+++ b/get-images-from-pdf/main.ts
@@ -8,7 +8,11 @@ const myFlow = flow.create('5ab692b4-ce12-48ab-abab-f0176f5f874a', 'Imported Get
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/get-images-from-pdf/fixtures'; msg.fixtures_dir = fixtures; msg.source_pdf = fixtures + '/with_images.pdf'; msg.images_dir = fixtures + '/images'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/get-images-from-pdf/fixtures';
+msg.fixtures_dir = fixtures;
+msg.source_pdf = fixtures + '/with_images.pdf';
+msg.images_dir = fixtures + '/images';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask PDF', {
       inTitle: Custom('Extract images from PDF'),

--- a/get-images-from-pdf/subflows/a11000.ts
+++ b/get-images-from-pdf/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/get-images-from-pdf/fixtures'; msg._dl_dir = fixtures; msg._dl_with_images_pdf = fixtures + '/with_images.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/get-images-from-pdf/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_with_images_pdf = fixtures + '/with_images.pdf';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/get-login-name-using-python/main.ts
+++ b/get-login-name-using-python/main.ts
@@ -11,7 +11,10 @@ const myFlow = flow.create('c89dcd58-3c35-47b8-8d1c-9107ed5ff752', 'Imported Get
       outStdout: Message('login_name_raw'),
     })
     .then('a10003', 'Core.Programming.Function', 'Build Dialog Text', {
-      func: `var user = String(msg.login_name_raw || ''); while (user.length && (user.charCodeAt(user.length - 1) === 10 || user.charCodeAt(user.length - 1) === 13)) user = user.slice(0, -1); msg.dialog_text = 'Machine login name: ' + user; return msg;`,
+      func: `var user = String(msg.login_name_raw || '');
+while (user.length && (user.charCodeAt(user.length - 1) === 10 || user.charCodeAt(user.length - 1) === 13)) user = user.slice(0, -1);
+msg.dialog_text = 'Machine login name: ' + user;
+return msg;`,
     })
     .then('a10004', 'Core.Dialog.MessageBox', 'Show Output', {
       inTitle: Custom('Login name'),

--- a/get-metadata-of-web-page/main.ts
+++ b/get-metadata-of-web-page/main.ts
@@ -12,7 +12,9 @@ const myFlow = flow.create('61fc2c33-d57d-4a26-8e18-d1d828480019', 'Imported Get
     })
     .then('a10003', 'Core.Programming.Function', 'Branch On Cancel', {
       outputs: 2,
-      func: `var u = (msg.url_input || '').trim(); if (!u) return [null, msg]; if (!/^https?:\\/\\//i.test(u)) u = 'https://' + u; msg.url = u; return [msg, null];`,
+      func: `var u = (msg.url_input || '').trim();
+if (!u) return [null, msg];
+if (!/^https?:\\/\\//i.test(u)) u = 'https://' + u; msg.url = u; return [msg, null];`,
     });
 
   f.node('a10004', 'Core.Browser.Open', 'Launch Browser', {

--- a/get-metadata-of-web-page/subflows/a10020.ts
+++ b/get-metadata-of-web-page/subflows/a10020.ts
@@ -8,7 +8,8 @@ subflow.create('Title', (f) => {
       outResult: Message('web_page_title'),
     })
     .then('b10003', 'Core.Programming.Function', 'Build Dialog Text', {
-      func: `msg.dialog_text = 'The title of the given web page is:\\n\\n' + (msg.web_page_title || ''); return msg;`,
+      func: `msg.dialog_text = 'The title of the given web page is:\\n\\n' + (msg.web_page_title || '');
+return msg;`,
     })
     .then('b10004', 'Core.Dialog.MessageBox', 'Show Title', {
       inTitle: Custom('Get metadata of a webpage.'),

--- a/get-metadata-of-web-page/subflows/a10021.ts
+++ b/get-metadata-of-web-page/subflows/a10021.ts
@@ -13,7 +13,8 @@ subflow.create('Keywords', (f) => {
     });
 
   f.node('b20004', 'Core.Programming.Function', 'Build Found Text', {
-    func: `msg.dialog_text = 'The keywords specified for the given web page are:\\n\\n' + msg.web_page_keywords; return msg;`,
+    func: `msg.dialog_text = 'The keywords specified for the given web page are:\\n\\n' + msg.web_page_keywords;
+return msg;`,
   })
     .then('b20005', 'Core.Dialog.MessageBox', 'Show Keywords', {
       inTitle: Custom('Get metadata of a webpage.'),
@@ -22,7 +23,8 @@ subflow.create('Keywords', (f) => {
     });
 
   f.node('b20006', 'Core.Programming.Function', 'Build Missing Text', {
-    func: `msg.dialog_text = 'No keywords specified for the web page:\\n' + msg.url; return msg;`,
+    func: `msg.dialog_text = 'No keywords specified for the web page:\\n' + msg.url;
+return msg;`,
   })
     .then('b20007', 'Core.Dialog.MessageBox', 'Show No Keywords', {
       inTitle: Custom('Get metadata of a webpage.'),

--- a/get-metadata-of-web-page/subflows/a10022.ts
+++ b/get-metadata-of-web-page/subflows/a10022.ts
@@ -13,7 +13,8 @@ subflow.create('Description', (f) => {
     });
 
   f.node('b30004', 'Core.Programming.Function', 'Build Found Text', {
-    func: `msg.dialog_text = 'The description for the given web page is:\\n\\n' + msg.web_page_description; return msg;`,
+    func: `msg.dialog_text = 'The description for the given web page is:\\n\\n' + msg.web_page_description;
+return msg;`,
   })
     .then('b30005', 'Core.Dialog.MessageBox', 'Show Description', {
       inTitle: Custom('Get metadata of a webpage.'),
@@ -22,7 +23,8 @@ subflow.create('Description', (f) => {
     });
 
   f.node('b30006', 'Core.Programming.Function', 'Build Missing Text', {
-    func: `msg.dialog_text = 'No description specified for the web page:\\n' + msg.url; return msg;`,
+    func: `msg.dialog_text = 'No description specified for the web page:\\n' + msg.url;
+return msg;`,
   })
     .then('b30007', 'Core.Dialog.MessageBox', 'Show No Description', {
       inTitle: Custom('Get metadata of a webpage.'),

--- a/get-metadata-of-web-page/subflows/a10023.ts
+++ b/get-metadata-of-web-page/subflows/a10023.ts
@@ -3,7 +3,8 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('HTML Source', (f) => {
   f.node('b40001', 'Core.Flow.Begin', 'Begin', {})
     .then('b40002', 'Core.Programming.Function', 'Build Prompt Text', {
-      func: `msg.dialog_text = 'Do you want to save the HTML source of the given webpage locally?\\nWeb page URL: ' + msg.url + '  '; return msg;`,
+      func: `msg.dialog_text = 'Do you want to save the HTML source of the given webpage locally?\\nWeb page URL: ' + msg.url + '  ';
+return msg;`,
     })
     .then('b40003', 'Core.Dialog.MessageBox', 'Ask To Save', {
       inTitle: Custom('Do you want to save HTML source? '),
@@ -13,7 +14,8 @@ subflow.create('HTML Source', (f) => {
     })
     .then('b40004', 'Core.Programming.Function', 'Branch On Yes', {
       outputs: 2,
-      func: `msg.default_save_path = global.get('$Home$') + '/Desktop/web_source.txt'; return msg.save_confirmed ? [msg, null] : [null, msg];`,
+      func: `msg.default_save_path = global.get('$Home$') + '/Desktop/web_source.txt';
+return msg.save_confirmed ? [msg, null] : [null, msg];`,
     });
 
   f.node('b40005', 'Core.Dialog.InputBox', 'Ask For Save Path', {

--- a/get-number-of-pages/main.ts
+++ b/get-number-of-pages/main.ts
@@ -8,7 +8,8 @@ const myFlow = flow.create('91118709-f8ed-48ed-a134-27b76c421d46', 'Imported Get
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10020', 'Core.Programming.Function', 'Build Default', {
-      func: `msg.default_pdf = global.get('$Home$') + '/templates/pdf-automation/get-number-of-pages/fixtures/sample.pdf'; return msg;`,
+      func: `msg.default_pdf = global.get('$Home$') + '/templates/pdf-automation/get-number-of-pages/fixtures/sample.pdf';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask PDF Path', {
       inTitle: Custom('Find the number of pages in PDF'),
@@ -22,7 +23,10 @@ const myFlow = flow.create('91118709-f8ed-48ed-a134-27b76c421d46', 'Imported Get
     });
 
   f.node('a10004', 'Core.Programming.Function', 'Build Temp Dir', {
-    func: `var p = msg.pdf_path; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); msg.count_dir = p.substring(0, lastSlash) + '/_page_count'; return msg;`,
+    func: `var p = msg.pdf_path;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+msg.count_dir = p.substring(0, lastSlash) + '/_page_count';
+return msg;`,
   })
     .then('a10021', 'Core.FileSystem.Delete', 'Clear Temp Dir', {
       inPath: Message('count_dir'),
@@ -47,7 +51,11 @@ const myFlow = flow.create('91118709-f8ed-48ed-a134-27b76c421d46', 'Imported Get
       outFiles: Message('page_files'),
     })
     .then('a10008', 'Core.Programming.Function', 'Count And Clean', {
-      func: `var list = msg.page_files || []; var pages = 0; for (var i = 0; i < list.length; i++) { if (!list[i].IsDir) pages++; } msg.page_count = pages || 0; msg.dialog_text = 'The selected PDF file has ' + msg.page_count + ' pages.'; return msg;`,
+      func: `var list = msg.page_files || [];
+var pages = 0;
+for (var i = 0; i < list.length; i++) { if (!list[i].IsDir) pages++; } msg.page_count = pages || 0;
+msg.dialog_text = 'The selected PDF file has ' + msg.page_count + ' pages.';
+return msg;`,
     })
     .then('a10009', 'Core.FileSystem.Delete', 'Remove Temp Dir', {
       inPath: Message('count_dir'),

--- a/get-number-of-pages/subflows/a11000.ts
+++ b/get-number-of-pages/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/get-number-of-pages/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_pdf = fixtures + '/sample.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/get-number-of-pages/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_pdf = fixtures + '/sample.pdf';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/get-position-of-subtext/main.ts
+++ b/get-position-of-subtext/main.ts
@@ -18,11 +18,13 @@ const myFlow = flow.create('507d615d-5c62-4cdb-9baf-95cd07933b45', 'Imported Get
     })
     .then('a10004', 'Core.Programming.Function', 'Find Position', {
       outputs: 2,
-      func: `msg.position = (msg.text_var || '').indexOf(msg.subtext_var || ''); return msg.position >= 0 ? [msg, null] : [null, msg];`,
+      func: `msg.position = (msg.text_var || '').indexOf(msg.subtext_var || '');
+return msg.position >= 0 ? [msg, null] : [null, msg];`,
     });
 
   f.node('a10005', 'Core.Programming.Function', 'Build Found Text', {
-    func: `msg.dialog_text = "The subtext '" + msg.subtext_var + "' begins at character  " + msg.position; return msg;`,
+    func: `msg.dialog_text = "The subtext '" + msg.subtext_var + "' begins at character  " + msg.position;
+return msg;`,
   })
     .then('a10006', 'Core.Dialog.MessageBox', 'Show Found', {
       inTitle: Custom('Flow ran successfully!'),
@@ -31,7 +33,8 @@ const myFlow = flow.create('507d615d-5c62-4cdb-9baf-95cd07933b45', 'Imported Get
     });
 
   f.node('a10007', 'Core.Programming.Function', 'Build Not Found Text', {
-    func: `msg.dialog_text = "The subtext '" + msg.subtext_var + "' wasn't found in the given text. "; return msg;`,
+    func: `msg.dialog_text = "The subtext '" + msg.subtext_var + "' wasn't found in the given text. ";
+return msg;`,
   })
     .then('a10008', 'Core.Dialog.MessageBox', 'Show Not Found', {
       inTitle: Custom('Flow ran successfully!'),

--- a/get-previous-working-date/main.ts
+++ b/get-previous-working-date/main.ts
@@ -17,7 +17,9 @@ const myFlow = flow.create('1e63fc61-ecc8-40f3-9dee-e58a51d9debb', 'Imported Get
       outParts: Message('today_parts'),
     })
     .then('a10004', 'Core.Programming.Function', 'Compute Day Offset', {
-      func: `var w = msg.today_parts.weekday; msg.day_offset = (w === 'Sunday' || w === 0) ? -2 : (w === 'Monday' || w === 1) ? -3 : -1; return msg;`,
+      func: `var w = msg.today_parts.weekday;
+msg.day_offset = (w === 'Sunday' || w === 0) ? -2 : (w === 'Monday' || w === 1) ? -3 : -1;
+return msg;`,
     })
     .then('a10005', 'Robomotion.DateTime.Add', 'Previous Working Day', {
       inTime: Message('today'),
@@ -39,7 +41,8 @@ const myFlow = flow.create('1e63fc61-ecc8-40f3-9dee-e58a51d9debb', 'Imported Get
       outFormattedTime: Message('month_name'),
     })
     .then('a10008', 'Core.Programming.Function', 'Build Dialog Text', {
-      func: `msg.dialog_text = 'The last working day was:\\n\\nDay: ' + msg.previous_parts.day + '\\nMonth: ' + msg.month_name + '\\nYear: ' + msg.previous_parts.year; return msg;`,
+      func: `msg.dialog_text = 'The last working day was:\\n\\nDay: ' + msg.previous_parts.day + '\\nMonth: ' + msg.month_name + '\\nYear: ' + msg.previous_parts.year;
+return msg;`,
     })
     .then('a10009', 'Core.Dialog.MessageBox', 'Show Result', {
       inTitle: Custom(' '),

--- a/gui-testing-calculator/subflows/a10020.ts
+++ b/gui-testing-calculator/subflows/a10020.ts
@@ -21,7 +21,16 @@ subflow.create('Set Variables', (f) => {
       outFormattedTime: Message('formatted_date_time'),
     })
     .then('b20005', 'Core.Programming.Function', 'Compose Paths', {
-      func: `var docs = global.get('$Home$') + '/Documents'; msg.app_name = 'Calculator'; msg.subflow_name = 'Main'; msg.fail_label = 'Fail'; msg.pass_label = 'Pass'; msg.special_folder_path = docs; msg.os_build = String(msg.os_build_raw || '').trim(); msg.temp_report_file_name = docs + '/TestReport_DemoGUIAutomationTestPass.csv'; msg.report_file_name = docs + '/TestReport_DemoGUIAutomationTestPass_' + msg.formatted_date_time + '.csv'; return msg;`,
+      func: `var docs = global.get('$Home$') + '/Documents';
+msg.app_name = 'Calculator';
+msg.subflow_name = 'Main';
+msg.fail_label = 'Fail';
+msg.pass_label = 'Pass';
+msg.special_folder_path = docs;
+msg.os_build = String(msg.os_build_raw || '').trim();
+msg.temp_report_file_name = docs + '/TestReport_DemoGUIAutomationTestPass.csv';
+msg.report_file_name = docs + '/TestReport_DemoGUIAutomationTestPass_' + msg.formatted_date_time + '.csv';
+return msg;`,
     })
     .then('b20006', 'Core.Flow.End', 'End', { sfPort: 0 });
 });

--- a/gui-testing-calculator/subflows/a10021.ts
+++ b/gui-testing-calculator/subflows/a10021.ts
@@ -7,7 +7,8 @@ subflow.create('Start Test Report', (f) => {
       continueOnError: true,
     })
     .then('b21003', 'Core.Programming.Function', 'Build Header', {
-      func: `msg.csv_line = 'Test,Outcome,Error,App Build,OS Build\\n'; return msg;`,
+      func: `msg.csv_line = 'Test,Outcome,Error,App Build,OS Build\\n';
+return msg;`,
     })
     .then('b21004', 'Core.FileSystem.WriteFile', 'Write Header', {
       inPath: Message('temp_report_file_name'),

--- a/gui-testing-calculator/subflows/a10022.ts
+++ b/gui-testing-calculator/subflows/a10022.ts
@@ -3,7 +3,8 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Launch App', (f) => {
   f.node('b22001', 'Core.Flow.Begin', 'Begin', {})
     .then('b22002', 'Core.Programming.Function', 'Label This Test', {
-      func: `msg.subflow_name = 'Verify the application can be launched'; return msg;`,
+      func: `msg.subflow_name = 'Verify the application can be launched';
+return msg;`,
     })
     .then('b22003', 'Core.Process.StartProcess', 'Start Calculator', {
       inFilePath: Custom('calc.exe'),
@@ -26,7 +27,9 @@ subflow.create('Launch App', (f) => {
       continueOnError: true,
     })
     .then('b22006', 'Core.Programming.Function', 'Build Pass Row', {
-      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim(); msg.csv_line = [msg.subflow_name, msg.pass_label, 'None', appBuild, msg.os_build].join(',') + '\\n'; return msg;`,
+      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim();
+msg.csv_line = [msg.subflow_name, msg.pass_label, 'None', appBuild, msg.os_build].join(',') + '\\n';
+return msg;`,
     })
     .then('b22007', 'Core.FileSystem.WriteFile', 'Append Pass Row', {
       inPath: Message('temp_report_file_name'),

--- a/gui-testing-calculator/subflows/a10023.ts
+++ b/gui-testing-calculator/subflows/a10023.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Resize and Position App', (f) => {
   f.node('b23001', 'Core.Flow.Begin', 'Begin', {})
     .then('b23002', 'Core.Programming.Function', 'Label This Test', {
-      func: `msg.subflow_name = 'Verify the application can be resized and positioned'; msg.calc_x = 1; msg.calc_y = 40; return msg;`,
+      func: `msg.subflow_name = 'Verify the application can be resized and positioned';
+msg.calc_x = 1;
+msg.calc_y = 40;
+return msg;`,
     })
     .then('b23003', 'Robomotion.WindowsAutomation.MoveWindow', 'Move Calculator', {
       inSelector: Custom('//Window[contains(@Name,"Calculator")]'),
@@ -11,7 +14,9 @@ subflow.create('Resize and Position App', (f) => {
       inY: Message('calc_y'),
     })
     .then('b23004', 'Core.Programming.Function', 'Build Pass Row', {
-      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim(); msg.csv_line = [msg.subflow_name, msg.pass_label, 'None', appBuild, msg.os_build].join(',') + '\\n'; return msg;`,
+      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim();
+msg.csv_line = [msg.subflow_name, msg.pass_label, 'None', appBuild, msg.os_build].join(',') + '\\n';
+return msg;`,
     })
     .then('b23005', 'Core.FileSystem.WriteFile', 'Append Pass Row', {
       inPath: Message('temp_report_file_name'),

--- a/gui-testing-calculator/subflows/a10024.ts
+++ b/gui-testing-calculator/subflows/a10024.ts
@@ -3,7 +3,8 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Navigation Menu', (f) => {
   f.node('b24001', 'Core.Flow.Begin', 'Begin', {})
     .then('b24002', 'Core.Programming.Function', 'Label This Test', {
-      func: `msg.subflow_name = 'Verify navigation within the Navigation Menu'; return msg;`,
+      func: `msg.subflow_name = 'Verify navigation within the Navigation Menu';
+return msg;`,
     })
     .then('b24003', 'Robomotion.WindowsAutomation.SendKey', 'Send Alt+2', {
       inSelector: Custom('//Window[contains(@Name,"Calculator")]'),
@@ -12,7 +13,9 @@ subflow.create('Navigation Menu', (f) => {
       optWaitTimeout: 10,
     })
     .then('b24004', 'Core.Programming.Function', 'Build Pass Row', {
-      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim(); msg.csv_line = [msg.subflow_name, msg.pass_label, 'None', appBuild, msg.os_build].join(',') + '\\n'; return msg;`,
+      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim();
+msg.csv_line = [msg.subflow_name, msg.pass_label, 'None', appBuild, msg.os_build].join(',') + '\\n';
+return msg;`,
     })
     .then('b24005', 'Core.FileSystem.WriteFile', 'Append Pass Row', {
       inPath: Message('temp_report_file_name'),

--- a/gui-testing-calculator/subflows/a10025.ts
+++ b/gui-testing-calculator/subflows/a10025.ts
@@ -3,13 +3,16 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Close App', (f) => {
   f.node('b25001', 'Core.Flow.Begin', 'Begin', {})
     .then('b25002', 'Core.Programming.Function', 'Label This Test', {
-      func: `msg.subflow_name = 'Verify the application can be closed'; return msg;`,
+      func: `msg.subflow_name = 'Verify the application can be closed';
+return msg;`,
     })
     .then('b25003', 'Robomotion.WindowsAutomation.CloseWindow', 'Close Calculator', {
       inSelector: Custom('//Window[contains(@Name,"Calculator")]'),
     })
     .then('b25004', 'Core.Programming.Function', 'Build Pass Row', {
-      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim(); msg.csv_line = [msg.subflow_name, msg.pass_label, 'None', appBuild, msg.os_build].join(',') + '\\n'; return msg;`,
+      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim();
+msg.csv_line = [msg.subflow_name, msg.pass_label, 'None', appBuild, msg.os_build].join(',') + '\\n';
+return msg;`,
     })
     .then('b25005', 'Core.FileSystem.WriteFile', 'Append Pass Row', {
       inPath: Message('temp_report_file_name'),

--- a/gui-testing-calculator/subflows/a10026.ts
+++ b/gui-testing-calculator/subflows/a10026.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Log Errors', (f) => {
   f.node('b26001', 'Core.Flow.Begin', 'Begin', {})
     .then('b26002', 'Core.Programming.Function', 'Build Fail Row', {
-      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim(); var errText = (msg.error && (msg.error.message || msg.error.text)) ? (msg.error.message || msg.error.text) : String(msg.error || 'Unknown error'); msg.csv_line = [msg.subflow_name || 'Unknown', msg.fail_label, errText.replace(/,/g, ';'), appBuild, msg.os_build].join(',') + '\\n'; return msg;`,
+      func: `var appBuild = msg.app_name + ' ' + String(msg.product_version || '').trim();
+var errText = (msg.error && (msg.error.message || msg.error.text)) ? (msg.error.message || msg.error.text) : String(msg.error || 'Unknown error');
+msg.csv_line = [msg.subflow_name || 'Unknown', msg.fail_label, errText.replace(/,/g, ';'), appBuild, msg.os_build].join(',') + '\\n';
+return msg;`,
     })
     .then('b26003', 'Core.FileSystem.WriteFile', 'Append Fail Row', {
       inPath: Message('temp_report_file_name'),

--- a/gui-testing-calculator/subflows/a10028.ts
+++ b/gui-testing-calculator/subflows/a10028.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Finish Test Report', (f) => {
   f.node('b28001', 'Core.Flow.Begin', 'Begin', {})
     .then('b28002', 'Core.Programming.Function', 'Build Finalize Script', {
-      func: `var tmp = msg.temp_report_file_name; var out = msg.report_file_name; msg.finalize_args = ['-NoProfile', '-Command', "Get-Content -LiteralPath '" + tmp + "' | Where-Object { $_.Trim() -ne '' } | Out-File -Encoding UTF8 -LiteralPath '" + out + "'; Remove-Item -LiteralPath '" + tmp + "' -Force"]; return msg;`,
+      func: `var tmp = msg.temp_report_file_name;
+var out = msg.report_file_name;
+msg.finalize_args = ['-NoProfile', '-Command', "Get-Content -LiteralPath '" + tmp + "' | Where-Object { $_.Trim() -ne '' } | Out-File -Encoding UTF8 -LiteralPath '" + out + "'; Remove-Item -LiteralPath '" + tmp + "' -Force"];
+return msg;`,
     })
     .then('b28003', 'Core.Process.StartProcess', 'Finalize Report', {
       inFilePath: Custom('powershell'),
@@ -12,7 +15,8 @@ subflow.create('Finish Test Report', (f) => {
       continueOnError: true,
     })
     .then('b28004', 'Core.Programming.Function', 'Build Dialog Text', {
-      func: `msg.dialog_text = 'Test results are located in ' + msg.report_file_name; return msg;`,
+      func: `msg.dialog_text = 'Test results are located in ' + msg.report_file_name;
+return msg;`,
     });
 
   f.node('b28005', 'Core.Flow.Log', 'Log Location', {

--- a/launch-excel-and-extract-table/main.ts
+++ b/launch-excel-and-extract-table/main.ts
@@ -8,7 +8,9 @@ const myFlow = flow.create('50bb5c21-7c70-4f7c-b284-6c697d5759a6', 'Imported Lau
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10002', 'Core.Programming.Function', 'Build Default Path', {
-      func: `msg.default_excel_path = global.get('$Home$') + '/templates/excel-automation/launch-excel-and-extract-table/fixtures/sample.xlsx'; msg.retry_count = 0; return msg;`,
+      func: `msg.default_excel_path = global.get('$Home$') + '/templates/excel-automation/launch-excel-and-extract-table/fixtures/sample.xlsx';
+msg.retry_count = 0;
+return msg;`,
     })
     .then('a10003', 'Core.Dialog.InputBox', 'Ask Excel', {
       inTitle: Custom('Launch Excel and extract table'),
@@ -41,7 +43,9 @@ const myFlow = flow.create('50bb5c21-7c70-4f7c-b284-6c697d5759a6', 'Imported Lau
       applicationId: Message('excel_app_id'),
     })
     .then('a10008', 'Core.Programming.Function', 'Stringify Table', {
-      func: `var rows = (msg.excel_table && msg.excel_table.rows) || msg.excel_table || []; msg.excel_text = rows.map(function (row) { if (Array.isArray(row)) return row.join('\\t'); if (row && typeof row === 'object') return Object.keys(row).map(function (k) { return row[k]; }).join('\\t'); return String(row); }).join('\\n'); return msg;`,
+      func: `var rows = (msg.excel_table && msg.excel_table.rows) || msg.excel_table || [];
+msg.excel_text = rows.map(function (row) { if (Array.isArray(row)) return row.join('\\t'); if (row && typeof row === 'object') return Object.keys(row).map(function (k) { return row[k]; }).join('\\t'); return String(row); }).join('\\n');
+return msg;`,
     })
     .then('a10009', 'Core.Dialog.MessageBox', 'Show Table', {
       inTitle: Custom('Excel table values extracted:'),
@@ -54,7 +58,8 @@ const myFlow = flow.create('50bb5c21-7c70-4f7c-b284-6c697d5759a6', 'Imported Lau
   })
     .then('a10021', 'Core.Programming.Function', 'Check Retry', {
       outputs: 2,
-      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1; return [msg, null]; } return [null, msg];`,
+      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1;
+return [msg, null]; } return [null, msg];`,
     });
 
   f.node('a10022', 'Core.Programming.Sleep', 'Wait 2s', {

--- a/launch-excel-and-extract-table/subflows/a11000.ts
+++ b/launch-excel-and-extract-table/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/launch-excel-and-extract-table/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_xlsx = fixtures + '/sample.xlsx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/launch-excel-and-extract-table/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_xlsx = fixtures + '/sample.xlsx';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/launch-excel/main.ts
+++ b/launch-excel/main.ts
@@ -8,7 +8,9 @@ const myFlow = flow.create('c28d2bfc-5f2f-429f-bd49-a6642e5c6749', 'Imported Lau
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10002', 'Core.Programming.Function', 'Build Default Path', {
-      func: `msg.default_excel_path = global.get('$Home$') + '/templates/excel-automation/launch-excel/fixtures/sample.xlsx'; msg.retry_count = 0; return msg;`,
+      func: `msg.default_excel_path = global.get('$Home$') + '/templates/excel-automation/launch-excel/fixtures/sample.xlsx';
+msg.retry_count = 0;
+return msg;`,
     })
     .then('a10003', 'Core.Dialog.InputBox', 'Ask Excel', {
       inTitle: Custom('Launch Excel'),
@@ -38,7 +40,8 @@ const myFlow = flow.create('c28d2bfc-5f2f-429f-bd49-a6642e5c6749', 'Imported Lau
   })
     .then('a10021', 'Core.Programming.Function', 'Check Retry', {
       outputs: 2,
-      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1; return [msg, null]; } return [null, msg];`,
+      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1;
+return [msg, null]; } return [null, msg];`,
     });
 
   f.node('a10022', 'Core.Programming.Sleep', 'Wait 2s', {

--- a/launch-excel/subflows/a11000.ts
+++ b/launch-excel/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/launch-excel/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_xlsx = fixtures + '/sample.xlsx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/launch-excel/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_xlsx = fixtures + '/sample.xlsx';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/manipulate-excel-data-using-sql/main.ts
+++ b/manipulate-excel-data-using-sql/main.ts
@@ -6,7 +6,10 @@ const myFlow = flow.create('5893ef96-e317-4797-b2a6-0c5530aa1bed', 'Imported Man
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/manipulate-excel-data-using-sql/fixtures'; msg.excel_path = fixtures + '/sales.csv'; msg.output_csv_path = fixtures + '/sales_filtered.csv'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/manipulate-excel-data-using-sql/fixtures';
+msg.excel_path = fixtures + '/sales.csv';
+msg.output_csv_path = fixtures + '/sales_filtered.csv';
+return msg;`,
     })
     .then('a10003', 'Core.CSV.ReadCSV', 'Read Sales CSV', {
       inFilePath: Message('excel_path'),
@@ -17,13 +20,16 @@ const myFlow = flow.create('5893ef96-e317-4797-b2a6-0c5530aa1bed', 'Imported Man
       outTable: Message('full_table'),
     })
     .then('a10005', 'Core.Programming.Function', 'Filter Country USA', {
-      func: `msg.usa_rows = (msg.full_table.rows || []).filter(function(r){ return r.Country === 'USA'; }); return msg;`,
+      func: `msg.usa_rows = (msg.full_table.rows || []).filter(function(r){ return r.Country === 'USA'; });
+return msg;`,
     })
     .then('a10006', 'Core.Programming.Function', 'Insert New Sale', {
-      func: `msg.full_table.rows.push({ Country: 'Greece', Product: 'Paseo', Units: '2408' }); return msg;`,
+      func: `msg.full_table.rows.push({ Country: 'Greece', Product: 'Paseo', Units: '2408' });
+return msg;`,
     })
     .then('a10007', 'Core.Programming.Function', 'Update Carretera Units', {
-      func: `msg.full_table.rows = msg.full_table.rows.map(function(r){ return r.Product === 'Carretera' ? Object.assign({}, r, { Units: '1000' }) : r; }); return msg;`,
+      func: `msg.full_table.rows = msg.full_table.rows.map(function(r){ return r.Product === 'Carretera' ? Object.assign({}, r, { Units: '1000' }) : r; });
+return msg;`,
     })
     .then('a10009', 'Core.CSV.WriteCSV', 'Write Updated CSV', {
       inFilePath: Message('output_csv_path'),
@@ -33,7 +39,8 @@ const myFlow = flow.create('5893ef96-e317-4797-b2a6-0c5530aa1bed', 'Imported Man
       optHeaders: true,
     })
     .then('a10010', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'The example flow ran successfully!\\n\\nUSA rows selected: ' + msg.usa_rows.length + '\\nRows after INSERT+UPDATE: ' + msg.full_table.rows.length + '\\nUpdated CSV saved to: ' + msg.output_csv_path; return msg;`,
+      func: `msg.dialog_text = 'The example flow ran successfully!\\n\\nUSA rows selected: ' + msg.usa_rows.length + '\\nRows after INSERT+UPDATE: ' + msg.full_table.rows.length + '\\nUpdated CSV saved to: ' + msg.output_csv_path;
+return msg;`,
     })
     .then('a10011', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('Flow run completed '),

--- a/manipulate-excel-data-using-sql/subflows/a11000.ts
+++ b/manipulate-excel-data-using-sql/subflows/a11000.ts
@@ -3,7 +3,11 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/manipulate-excel-data-using-sql/fixtures'; msg._dl_dir = fixtures; msg._dl_sales_csv = fixtures + '/sales.csv'; msg._dl_sales_xlsx = fixtures + '/sales.xlsx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/manipulate-excel-data-using-sql/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sales_csv = fixtures + '/sales.csv';
+msg._dl_sales_xlsx = fixtures + '/sales.xlsx';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/merge-pdfs/main.ts
+++ b/merge-pdfs/main.ts
@@ -8,7 +8,11 @@ const myFlow = flow.create('00869a9e-4673-4196-8e25-f65888447289', 'Imported Mer
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10002', 'Core.Programming.Function', 'Seed PDF List', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/merge-pdfs/fixtures'; msg.fixtures_dir = fixtures; msg.default_dest = fixtures + '/output'; msg.pdf_list = [fixtures + '/doc_a.pdf', fixtures + '/doc_b.pdf', fixtures + '/doc_c.pdf', fixtures + '/doc_d.pdf']; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/merge-pdfs/fixtures';
+msg.fixtures_dir = fixtures;
+msg.default_dest = fixtures + '/output';
+msg.pdf_list = [fixtures + '/doc_a.pdf', fixtures + '/doc_b.pdf', fixtures + '/doc_c.pdf', fixtures + '/doc_d.pdf'];
+return msg;`,
     })
     .then('a10003', 'Core.Dialog.InputBox', 'Ask Destination', {
       inTitle: Custom(' Merge multiple PDFs into one'),
@@ -18,7 +22,13 @@ const myFlow = flow.create('00869a9e-4673-4196-8e25-f65888447289', 'Imported Mer
     })
     .then('a10004', 'Core.Programming.Function', 'Reverse And Plan', {
       outputs: 2,
-      func: `if (!msg.destination_folder) return [null, msg]; msg.pdf_list = msg.pdf_list.slice().reverse(); msg.suffix_base = 'MergedFile'; msg.suffix_ext = '.pdf'; msg.suffix_idx = 0; msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + msg.suffix_ext; return [msg, null];`,
+      func: `if (!msg.destination_folder) return [null, msg];
+msg.pdf_list = msg.pdf_list.slice().reverse();
+msg.suffix_base = 'MergedFile';
+msg.suffix_ext = '.pdf';
+msg.suffix_idx = 0;
+msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + msg.suffix_ext;
+return [msg, null];`,
     });
 
   f.node('a10005', 'Core.FileSystem.Create', 'Create Dest Dir', {
@@ -37,7 +47,10 @@ const myFlow = flow.create('00869a9e-4673-4196-8e25-f65888447289', 'Imported Mer
     })
     .then('a10012', 'Core.Programming.Function', 'Next Or Done', {
       outputs: 2,
-      func: `if (msg.candidate_exists) { msg.suffix_idx += 1; msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + '_' + (msg.suffix_idx + 1) + msg.suffix_ext; return [msg, null]; } msg.merged_path = msg.candidate_path; return [null, msg];`,
+      func: `if (msg.candidate_exists) { msg.suffix_idx += 1;
+msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + '_' + (msg.suffix_idx + 1) + msg.suffix_ext;
+return [msg, null]; } msg.merged_path = msg.candidate_path;
+return [null, msg];`,
     });
 
   f.node('a10013', 'Core.Flow.GoTo', 'Loop Back', {
@@ -49,7 +62,8 @@ const myFlow = flow.create('00869a9e-4673-4196-8e25-f65888447289', 'Imported Mer
     inPDFPathSave: Message('merged_path'),
   })
     .then('a10007', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'The merged file has been saved in: ' + msg.merged_path; return msg;`,
+      func: `msg.dialog_text = 'The merged file has been saved in: ' + msg.merged_path;
+return msg;`,
     })
     .then('a10008', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('Done!'),

--- a/merge-pdfs/subflows/a11000.ts
+++ b/merge-pdfs/subflows/a11000.ts
@@ -3,7 +3,13 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/merge-pdfs/fixtures'; msg._dl_dir = fixtures; msg._dl_doc_a_pdf = fixtures + '/doc_a.pdf'; msg._dl_doc_b_pdf = fixtures + '/doc_b.pdf'; msg._dl_doc_c_pdf = fixtures + '/doc_c.pdf'; msg._dl_doc_d_pdf = fixtures + '/doc_d.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/merge-pdfs/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_doc_a_pdf = fixtures + '/doc_a.pdf';
+msg._dl_doc_b_pdf = fixtures + '/doc_b.pdf';
+msg._dl_doc_c_pdf = fixtures + '/doc_c.pdf';
+msg._dl_doc_d_pdf = fixtures + '/doc_d.pdf';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/merge-two-pdfs/main.ts
+++ b/merge-two-pdfs/main.ts
@@ -8,7 +8,12 @@ const myFlow = flow.create('6204fa75-f522-416a-a565-b4c06fbd9c2b', 'Imported Mer
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10002', 'Core.Programming.Function', 'Build Defaults', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/merge-two-pdfs/fixtures'; msg.fixtures_dir = fixtures; msg.default_first = fixtures + '/first_three.pdf'; msg.default_second = fixtures + '/last_two.pdf'; msg.default_dest = fixtures + '/output'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/merge-two-pdfs/fixtures';
+msg.fixtures_dir = fixtures;
+msg.default_first = fixtures + '/first_three.pdf';
+msg.default_second = fixtures + '/last_two.pdf';
+msg.default_dest = fixtures + '/output';
+return msg;`,
     })
     .then('a10003', 'Core.Dialog.InputBox', 'Ask First PDF', {
       inTitle: Custom(' Merge two PDFs into one.'),
@@ -30,7 +35,13 @@ const myFlow = flow.create('6204fa75-f522-416a-a565-b4c06fbd9c2b', 'Imported Mer
     })
     .then('a10006', 'Core.Programming.Function', 'Validate Inputs', {
       outputs: 2,
-      func: `if (!msg.first_doc || !msg.second_doc || !msg.destination_folder) return [null, msg]; msg.pdf_paths = [msg.second_doc, msg.first_doc]; msg.suffix_base = 'MergedFile'; msg.suffix_ext = '.pdf'; msg.suffix_idx = 0; msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + msg.suffix_ext; return [msg, null];`,
+      func: `if (!msg.first_doc || !msg.second_doc || !msg.destination_folder) return [null, msg];
+msg.pdf_paths = [msg.second_doc, msg.first_doc];
+msg.suffix_base = 'MergedFile';
+msg.suffix_ext = '.pdf';
+msg.suffix_idx = 0;
+msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + msg.suffix_ext;
+return [msg, null];`,
     });
 
   f.node('a10007', 'Core.FileSystem.Create', 'Create Dest Dir', {
@@ -49,7 +60,10 @@ const myFlow = flow.create('6204fa75-f522-416a-a565-b4c06fbd9c2b', 'Imported Mer
     })
     .then('a10012', 'Core.Programming.Function', 'Next Or Done', {
       outputs: 2,
-      func: `if (msg.candidate_exists) { msg.suffix_idx += 1; msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + '_' + (msg.suffix_idx + 1) + msg.suffix_ext; return [msg, null]; } msg.merged_path = msg.candidate_path; return [null, msg];`,
+      func: `if (msg.candidate_exists) { msg.suffix_idx += 1;
+msg.candidate_path = msg.destination_folder + '/' + msg.suffix_base + '_' + (msg.suffix_idx + 1) + msg.suffix_ext;
+return [msg, null]; } msg.merged_path = msg.candidate_path;
+return [null, msg];`,
     });
 
   f.node('a10013', 'Core.Flow.GoTo', 'Loop Back', {
@@ -61,7 +75,8 @@ const myFlow = flow.create('6204fa75-f522-416a-a565-b4c06fbd9c2b', 'Imported Mer
     inPDFPathSave: Message('merged_path'),
   })
     .then('a10015', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'The merged file has been saved in: ' + msg.merged_path; return msg;`,
+      func: `msg.dialog_text = 'The merged file has been saved in: ' + msg.merged_path;
+return msg;`,
     })
     .then('a10016', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('Done!'),

--- a/merge-two-pdfs/subflows/a11000.ts
+++ b/merge-two-pdfs/subflows/a11000.ts
@@ -3,7 +3,11 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/merge-two-pdfs/fixtures'; msg._dl_dir = fixtures; msg._dl_first_three_pdf = fixtures + '/first_three.pdf'; msg._dl_last_two_pdf = fixtures + '/last_two.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/merge-two-pdfs/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_first_three_pdf = fixtures + '/first_three.pdf';
+msg._dl_last_two_pdf = fixtures + '/last_two.pdf';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/open-a-folder/main.ts
+++ b/open-a-folder/main.ts
@@ -5,7 +5,8 @@ const myFlow = flow.create('024d427e-0ed0-441d-974a-c56ac07215ca', 'Imported Ope
 
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a10002', 'Core.Programming.Function', 'Build Documents Path', {
-      func: `msg.documents_folder_path = global.get('$Home$') + '/Documents'; return msg;`,
+      func: `msg.documents_folder_path = global.get('$Home$') + '/Documents';
+return msg;`,
     })
     .then('a10003', 'Core.Dialog.InputBox', 'Ask Folder', {
       inTitle: Custom('Open a folder'),
@@ -19,7 +20,8 @@ const myFlow = flow.create('024d427e-0ed0-441d-974a-c56ac07215ca', 'Imported Ope
     });
 
   f.node('a10005', 'Core.Programming.Function', 'Build Args', {
-    func: `msg.explorer_args = [msg.selected_folder]; return msg;`,
+    func: `msg.explorer_args = [msg.selected_folder];
+return msg;`,
   })
     .then('a10006', 'Core.Process.StartProcess', 'Launch Explorer', {
       inFilePath: Custom('explorer.exe'),

--- a/open-a-web-page/main.ts
+++ b/open-a-web-page/main.ts
@@ -12,7 +12,9 @@ const myFlow = flow.create('01abdb64-744a-447d-a38d-f5389c5c4735', 'Imported Ope
     })
     .then('a10003', 'Core.Programming.Function', 'Branch On Cancel', {
       outputs: 2,
-      func: `var u = (msg.url_input || '').trim(); if (!u) return [null, msg]; if (!/^https?:\\/\\//i.test(u)) u = 'https://' + u; msg.url = u; msg.retry_count = 0; return [msg, null];`,
+      func: `var u = (msg.url_input || '').trim();
+if (!u) return [null, msg];
+if (!/^https?:\\/\\//i.test(u)) u = 'https://' + u; msg.url = u; msg.retry_count = 0; return [msg, null];`,
     })
     .then('a10010', 'Core.Flow.GoTo', 'Enter Retry', {
       optNodes: { type: 'goto', ids: ['a10011'], all: false },
@@ -36,7 +38,8 @@ const myFlow = flow.create('01abdb64-744a-447d-a38d-f5389c5c4735', 'Imported Ope
   })
     .then('a10021', 'Core.Programming.Function', 'Check Retry', {
       outputs: 2,
-      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1; return [msg, null]; } return [null, msg];`,
+      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1;
+return [msg, null]; } return [null, msg];`,
     });
 
   f.node('a10022', 'Core.Programming.Sleep', 'Wait 2s', {

--- a/print-current-weeks-calendar/main.ts
+++ b/print-current-weeks-calendar/main.ts
@@ -7,7 +7,9 @@ const myFlow = flow.create('80648b70-905d-4588-ac4d-e093699cde22', 'Imported Pri
 
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a10002', 'Core.Programming.Function', 'Build Paths', {
-      func: `msg.desktop_folder = global.get('$Home$') + '/Desktop'; msg.image_path = msg.desktop_folder + '/calendar.jpg'; return msg;`,
+      func: `msg.desktop_folder = global.get('$Home$') + '/Desktop';
+msg.image_path = msg.desktop_folder + '/calendar.jpg';
+return msg;`,
     })
     .then('a10003', 'Core.Process.StartProcess', 'Launch Outlook', {
       inFilePath: Custom('C:/Program Files/Microsoft Office/root/Office16/OUTLOOK.EXE'),
@@ -43,7 +45,8 @@ const myFlow = flow.create('80648b70-905d-4588-ac4d-e093699cde22', 'Imported Pri
       optWaitTimeout: 10,
     })
     .then('a10009', 'Core.Programming.Function', 'Build Print Args', {
-      func: `msg.print_args = ['-NoProfile', '-Command', 'Start-Process -FilePath ' + JSON.stringify(msg.image_path) + ' -Verb Print']; return msg;`,
+      func: `msg.print_args = ['-NoProfile', '-Command', 'Start-Process -FilePath ' + JSON.stringify(msg.image_path) + ' -Verb Print'];
+return msg;`,
     })
     .then('a10010', 'Core.Process.StartProcess', 'Send To Printer', {
       inFilePath: Custom('powershell'),
@@ -59,7 +62,8 @@ const myFlow = flow.create('80648b70-905d-4588-ac4d-e093699cde22', 'Imported Pri
       continueOnError: true,
     })
     .then('a10013', 'Core.Programming.Function', 'Build Kill Args', {
-      func: `msg.kill_args = ['/F', '/IM', 'outlook.exe']; return msg;`,
+      func: `msg.kill_args = ['/F', '/IM', 'outlook.exe'];
+return msg;`,
     })
     .then('a10014', 'Core.Process.StartProcess', 'Close Outlook', {
       inFilePath: Custom('taskkill'),

--- a/print-documents/main.ts
+++ b/print-documents/main.ts
@@ -6,7 +6,9 @@ const myFlow = flow.create('3de32a36-de6a-41a0-97f8-75192297d291', 'Imported Pri
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Seed Fixtures Dir', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/print-documents/fixtures'; msg.fixtures_dir = fixtures; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/print-documents/fixtures';
+msg.fixtures_dir = fixtures;
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.MessageBox', 'Intro', {
       inTitle: Custom('Print documents'),
@@ -16,7 +18,8 @@ const myFlow = flow.create('3de32a36-de6a-41a0-97f8-75192297d291', 'Imported Pri
       optType: 'info',
     })
     .then('a10003', 'Core.Programming.Function', 'Seed File List', {
-      func: `msg.files_to_print = [msg.fixtures_dir + '/hello.txt']; return msg;`,
+      func: `msg.files_to_print = [msg.fixtures_dir + '/hello.txt'];
+return msg;`,
     })
     .then('a10004', 'Core.Flow.GoTo', 'Enter Loop', {
       optNodes: { type: 'goto', ids: ['a10010'], all: false },
@@ -29,7 +32,8 @@ const myFlow = flow.create('3de32a36-de6a-41a0-97f8-75192297d291', 'Imported Pri
     });
 
   f.node('a10012', 'Core.Programming.Function', 'Build Print Command', {
-    func: `msg.print_args = ['-NoProfile', '-Command', 'Start-Process -FilePath ' + JSON.stringify(msg.file_to_print) + ' -Verb Print']; return msg;`,
+    func: `msg.print_args = ['-NoProfile', '-Command', 'Start-Process -FilePath ' + JSON.stringify(msg.file_to_print) + ' -Verb Print'];
+return msg;`,
   })
     .then('a10013', 'Core.Process.StartProcess', 'Send To Printer', {
       inFilePath: Custom('powershell'),

--- a/print-documents/subflows/a11000.ts
+++ b/print-documents/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/print-documents/fixtures'; msg._dl_dir = fixtures; msg._dl_hello_txt = fixtures + '/hello.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/print-documents/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_hello_txt = fixtures + '/hello.txt';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/run-an-application/main.ts
+++ b/run-an-application/main.ts
@@ -5,7 +5,8 @@ const myFlow = flow.create('04ffb135-bfcb-48a0-b14c-c58ea797d3e1', 'Imported Run
 
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a10002', 'Core.Programming.Function', 'Build Desktop Path', {
-      func: `msg.desktop_folder_path = global.get('$Home$') + '/Desktop'; return msg;`,
+      func: `msg.desktop_folder_path = global.get('$Home$') + '/Desktop';
+return msg;`,
     })
     .then('a10003', 'Core.Dialog.InputBox', 'Ask App Path', {
       inTitle: Custom('Run an application'),

--- a/search-and-replace-excel-values/main.ts
+++ b/search-and-replace-excel-values/main.ts
@@ -8,7 +8,10 @@ const myFlow = flow.create('d6ffdf7e-2a44-408b-a784-5de7c89fc7f7', 'Imported Sea
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Build Default Path', {
-      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/search-and-replace-excel-values/fixtures'; msg.fixtures_dir = fixtures; msg.sample_xlsx = fixtures + '/sample.xlsx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/search-and-replace-excel-values/fixtures';
+msg.fixtures_dir = fixtures;
+msg.sample_xlsx = fixtures + '/sample.xlsx';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask Find Text', {
       inTitle: Custom('Search and replace Excel values'),
@@ -36,7 +39,9 @@ const myFlow = flow.create('d6ffdf7e-2a44-408b-a784-5de7c89fc7f7', 'Imported Sea
     })
     .then('a10006', 'Core.Programming.Function', 'Validate', {
       outputs: 2,
-      func: `if (!msg.text_to_find || !msg.selected_file || !/\\.(xls\\w*|csv)$/i.test(msg.selected_file)) return [null, msg]; msg.rename_function = (msg.rename_function || 'all').trim().toLowerCase() === 'first' ? 'first' : 'all'; return [msg, null];`,
+      func: `if (!msg.text_to_find || !msg.selected_file || !/\\.(xls\\w*|csv)$/i.test(msg.selected_file)) return [null, msg];
+msg.rename_function = (msg.rename_function || 'all').trim().toLowerCase() === 'first' ? 'first' : 'all';
+return [msg, null];`,
     });
 
   f.node('a10007', 'Robomotion.MicrosoftExcel.OpenExcel', 'Open Excel', {
@@ -51,7 +56,9 @@ const myFlow = flow.create('d6ffdf7e-2a44-408b-a784-5de7c89fc7f7', 'Imported Sea
       foundCells: Message('found_cells'),
     })
     .then('a10009', 'Core.Programming.Function', 'Pick Cells To Replace', {
-      func: `var cells = msg.found_cells || []; msg.cells_to_replace = (msg.rename_function === 'first') ? cells.slice(0, 1) : cells; return msg;`,
+      func: `var cells = msg.found_cells || [];
+msg.cells_to_replace = (msg.rename_function === 'first') ? cells.slice(0, 1) : cells;
+return msg;`,
     })
     .then('a10010', 'Core.Flow.GoTo', 'Enter Loop', {
       optNodes: { type: 'goto', ids: ['a10020'], all: false },
@@ -64,7 +71,9 @@ const myFlow = flow.create('d6ffdf7e-2a44-408b-a784-5de7c89fc7f7', 'Imported Sea
     });
 
   f.node('a10022', 'Core.Programming.Function', 'Extract Cell Address', {
-    func: `var c = msg.current_cell; if (typeof c === 'string') { msg.cell_address = c; } else if (c && c.address) { msg.cell_address = c.address; } else if (c && c.Cell) { msg.cell_address = c.Cell; } else if (c && typeof c.column === 'number' && typeof c.row === 'number') { var col = String.fromCharCode(64 + c.column); msg.cell_address = col + c.row; } else { msg.cell_address = ''; } return msg;`,
+    func: `var c = msg.current_cell;
+if (typeof c === 'string') { msg.cell_address = c; } else if (c && c.address) { msg.cell_address = c.address; } else if (c && c.Cell) { msg.cell_address = c.Cell; } else if (c && typeof c.column === 'number' && typeof c.row === 'number') { var col = String.fromCharCode(64 + c.column);
+msg.cell_address = col + c.row; } else { msg.cell_address = ''; } return msg;`,
   })
     .then('a10023', 'Robomotion.MicrosoftExcel.SetCellValue', 'Replace Value', {
       applicationId: Message('excel_app_id'),

--- a/search-and-replace-excel-values/subflows/a11000.ts
+++ b/search-and-replace-excel-values/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/search-and-replace-excel-values/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_xlsx = fixtures + '/sample.xlsx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/excel-automation/search-and-replace-excel-values/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_xlsx = fixtures + '/sample.xlsx';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/send-text-to-notepad/main.ts
+++ b/send-text-to-notepad/main.ts
@@ -30,7 +30,8 @@ const myFlow = flow.create('911c07de-689e-4c3e-a378-c9f6b65818e7', 'Imported Sen
       continueOnError: true,
     })
     .then('a10005', 'Core.Programming.Function', 'Seed Text', {
-      func: `msg.notepad_text = ${JSON.stringify(notepadText)}; return msg;`,
+      func: `msg.notepad_text = ${JSON.stringify(notepadText)};
+return msg;`,
     })
     .then('a10006', 'Robomotion.WindowsAutomation.SetText', 'Populate Editor', {
       inSelector: Custom('//Window[contains(@Name,"Notepad")]//Edit'),

--- a/share-powerpoint-file-as-pdf/main.ts
+++ b/share-powerpoint-file-as-pdf/main.ts
@@ -22,7 +22,10 @@ const myFlow = flow.create('e4c34dfa-6f0e-44db-9460-d54ea4766344', 'Imported Sha
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Build Default Path', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/share-powerpoint-file-as-pdf/fixtures'; msg.fixtures_dir = fixtures; msg.deck_pptx = fixtures + '/deck.pptx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/share-powerpoint-file-as-pdf/fixtures';
+msg.fixtures_dir = fixtures;
+msg.deck_pptx = fixtures + '/deck.pptx';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask PowerPoint', {
       inTitle: Custom('Share PowerPoint as PDF'),
@@ -44,11 +47,24 @@ const myFlow = flow.create('e4c34dfa-6f0e-44db-9460-d54ea4766344', 'Imported Sha
     })
     .then('a10005', 'Core.Programming.Function', 'Derive Paths', {
       outputs: 2,
-      func: `if (!msg.selected_powerpoint || !/\\.pptx?$/i.test(msg.selected_powerpoint)) return [null, msg]; var p = msg.selected_powerpoint; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); var dir = p.substring(0, lastSlash); var base = p.substring(lastSlash + 1); var dot = base.lastIndexOf('.'); var stem = dot === -1 ? base : base.substring(0, dot); msg.directory = dir; msg.file_name_no_ext = stem; msg.pdf_path = dir + '/' + stem + '.pdf'; return [msg, null];`,
+      func: `if (!msg.selected_powerpoint || !/\\.pptx?$/i.test(msg.selected_powerpoint)) return [null, msg];
+var p = msg.selected_powerpoint;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+var dir = p.substring(0, lastSlash);
+var base = p.substring(lastSlash + 1);
+var dot = base.lastIndexOf('.');
+var stem = dot === -1 ? base : base.substring(0, dot);
+msg.directory = dir;
+msg.file_name_no_ext = stem;
+msg.pdf_path = dir + '/' + stem + '.pdf';
+return [msg, null];`,
     });
 
   f.node('a10006', 'Core.Programming.Function', 'Build Export Args', {
-    func: `var tpl = ${JSON.stringify(exportScriptTemplate)}; var script = tpl.replace('\${SRC}', JSON.stringify(msg.selected_powerpoint)).replace('\${DEST}', JSON.stringify(msg.pdf_path)); msg.export_args = ['-NoProfile', '-Command', script]; return msg;`,
+    func: `var tpl = ${JSON.stringify(exportScriptTemplate)};
+var script = tpl.replace('\${SRC}', JSON.stringify(msg.selected_powerpoint)).replace('\${DEST}', JSON.stringify(msg.pdf_path));
+msg.export_args = ['-NoProfile', '-Command', script];
+return msg;`,
   })
     .then('a10007', 'Core.Process.StartProcess', 'Export To PDF', {
       inFilePath: Custom('powershell'),

--- a/share-powerpoint-file-as-pdf/subflows/a10050.ts
+++ b/share-powerpoint-file-as-pdf/subflows/a10050.ts
@@ -3,7 +3,8 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Send PDF Via Outlook', (f) => {
   f.node('b10001', 'Core.Flow.Begin', 'Begin', {})
     .then('b10002', 'Core.Programming.Function', 'Build Attachment List', {
-      func: `msg.attachments = [msg.pdf_path]; return msg;`,
+      func: `msg.attachments = [msg.pdf_path];
+return msg;`,
     })
     .then('b10003', 'Robomotion.MicrosoftOutlook.SendMail', 'Send Mail', {
       to: Message('recipient_email'),

--- a/share-powerpoint-file-as-pdf/subflows/a11000.ts
+++ b/share-powerpoint-file-as-pdf/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/share-powerpoint-file-as-pdf/fixtures'; msg._dl_dir = fixtures; msg._dl_deck_pptx = fixtures + '/deck.pptx'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/desktop-automation/share-powerpoint-file-as-pdf/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_deck_pptx = fixtures + '/deck.pptx';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/sort-lines-of-text-file/main.ts
+++ b/sort-lines-of-text-file/main.ts
@@ -6,7 +6,9 @@ const myFlow = flow.create('7b17397d-8ab0-4eaf-8792-adb3e49b24af', 'Imported Sor
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('5355dc', 'Core.Programming.Function', 'Build Default Path', {
-      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/sort-lines-of-text-file/fixtures'; msg.fixture_path = fixtures + '/unsorted.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/sort-lines-of-text-file/fixtures';
+msg.fixture_path = fixtures + '/unsorted.txt';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.MessageBox', 'Show Description', {
       inTitle: Custom('Description'),
@@ -23,7 +25,8 @@ const myFlow = flow.create('7b17397d-8ab0-4eaf-8792-adb3e49b24af', 'Imported Sor
     })
     .then('a10004', 'Core.Programming.Function', 'Branch On Selection', {
       outputs: 2,
-      func: `var p = (msg.selected_text_file || '').trim(); return (p && /\\.txt$/i.test(p)) ? [msg, null] : [null, msg];`,
+      func: `var p = (msg.selected_text_file || '').trim();
+return (p && /\\.txt$/i.test(p)) ? [msg, null] : [null, msg];`,
     });
 
   f.node('a10005', 'Core.FileSystem.ReadFile', 'Read File', {
@@ -32,10 +35,23 @@ const myFlow = flow.create('7b17397d-8ab0-4eaf-8792-adb3e49b24af', 'Imported Sor
     outContent: Message('file_contents_raw'),
   })
     .then('a10006', 'Core.Programming.Function', 'Sort Lines', {
-      func: `var lf = String.fromCharCode(10); var lines = msg.file_contents_raw.split(lf); if (lines.length && lines[lines.length - 1] === '') lines.pop(); lines.sort(function (a, b) { return a.localeCompare(b); }); msg.sorted_text = lines.join(lf) + lf; return msg;`,
+      func: `var lf = String.fromCharCode(10);
+var lines = msg.file_contents_raw.split(lf);
+if (lines.length && lines[lines.length - 1] === '') lines.pop();
+lines.sort(function (a, b) { return a.localeCompare(b); });
+msg.sorted_text = lines.join(lf) + lf;
+return msg;`,
     })
     .then('a10007', 'Core.Programming.Function', 'Build Sorted Path', {
-      func: `var p = msg.selected_text_file; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); var dir = p.substring(0, lastSlash); var base = p.substring(lastSlash + 1); var dot = base.lastIndexOf('.'); var stem = dot === -1 ? base : base.substring(0, dot); var ext = dot === -1 ? '' : base.substring(dot); msg.sorted_file_path = dir + '/' + stem + '_Sorted' + ext; return msg;`,
+      func: `var p = msg.selected_text_file;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+var dir = p.substring(0, lastSlash);
+var base = p.substring(lastSlash + 1);
+var dot = base.lastIndexOf('.');
+var stem = dot === -1 ? base : base.substring(0, dot);
+var ext = dot === -1 ? '' : base.substring(dot);
+msg.sorted_file_path = dir + '/' + stem + '_Sorted' + ext;
+return msg;`,
     })
     .then('a10008', 'Core.FileSystem.WriteFile', 'Write Sorted File', {
       inPath: Message('sorted_file_path'),
@@ -44,7 +60,8 @@ const myFlow = flow.create('7b17397d-8ab0-4eaf-8792-adb3e49b24af', 'Imported Sor
       optMode: 'truncate',
     })
     .then('a10009', 'Core.Programming.Function', 'Build Results Text', {
-      func: `msg.dialog_text = 'The contents of the file:\\n\\n' + msg.selected_text_file + '\\n\\nhave been sorted and saved in:\\n\\n' + msg.sorted_file_path; return msg;`,
+      func: `msg.dialog_text = 'The contents of the file:\\n\\n' + msg.selected_text_file + '\\n\\nhave been sorted and saved in:\\n\\n' + msg.sorted_file_path;
+return msg;`,
     })
     .then('a10010', 'Core.Dialog.MessageBox', 'Show Results', {
       inTitle: Custom('Flow completed!'),

--- a/sort-lines-of-text-file/subflows/a11000.ts
+++ b/sort-lines-of-text-file/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/sort-lines-of-text-file/fixtures'; msg._dl_dir = fixtures; msg._dl_unsorted_txt = fixtures + '/unsorted.txt'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/text-manipulation/sort-lines-of-text-file/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_unsorted_txt = fixtures + '/unsorted.txt';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/split-pdf-by-half/main.ts
+++ b/split-pdf-by-half/main.ts
@@ -9,7 +9,8 @@ const myFlow = flow.create('e0cde9e6-363b-4cdd-a6f1-312fced760be', 'Imported Spl
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10022', 'Core.Programming.Function', 'Build Default', {
-      func: `msg.default_pdf = global.get('$Home$') + '/templates/pdf-automation/split-pdf-by-half/fixtures/sample.pdf'; return msg;`,
+      func: `msg.default_pdf = global.get('$Home$') + '/templates/pdf-automation/split-pdf-by-half/fixtures/sample.pdf';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask PDF', {
       inTitle: Custom('Split a PDF by half'),
@@ -23,13 +24,20 @@ const myFlow = flow.create('e0cde9e6-363b-4cdd-a6f1-312fced760be', 'Imported Spl
     });
 
   f.node('a10004', 'Core.Programming.Function', 'Derive Paths', {
-    func: `var p = msg.pdf_path; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); msg.directory = p.substring(0, lastSlash); msg.split_output_dir = msg.directory + '/split_halves_' + Date.now(); return msg;`,
+    func: `var p = msg.pdf_path;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+msg.directory = p.substring(0, lastSlash);
+msg.split_output_dir = msg.directory + '/split_halves_' + Date.now();
+return msg;`,
   })
     .then('a10020', 'Core.Flow.SubFlow', 'Get Page Count', {})
     .then('a10021', 'Core.Flow.SubFlow', 'Compute Half', {})
     .then('a10005', 'Core.Programming.Function', 'Plan Split', {
       outputs: 2,
-      func: `var c = Number(msg.page_count); if (!c || c < 2) return [null, msg]; msg.custom_pages = [msg.half + 1]; return [msg, null];`,
+      func: `var c = Number(msg.page_count);
+if (!c || c < 2) return [null, msg];
+msg.custom_pages = [msg.half + 1];
+return [msg, null];`,
     });
 
   f.node('a10006', 'Core.FileSystem.Create', 'Ensure Split Dir', {
@@ -43,7 +51,8 @@ const myFlow = flow.create('e0cde9e6-363b-4cdd-a6f1-312fced760be', 'Imported Spl
       optCustomPages: Message('custom_pages'),
     })
     .then('a10008', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'The output PDF files have been saved in:\\n' + msg.split_output_dir; return msg;`,
+      func: `msg.dialog_text = 'The output PDF files have been saved in:\\n' + msg.split_output_dir;
+return msg;`,
     })
     .then('a10009', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('Flow has been completed!'),

--- a/split-pdf-by-half/subflows/a10020.ts
+++ b/split-pdf-by-half/subflows/a10020.ts
@@ -3,7 +3,8 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Get Page Count', (f) => {
   f.node('b10001', 'Core.Flow.Begin', 'Begin', {})
     .then('b10002', 'Core.Programming.Function', 'Build Count Dir', {
-      func: `msg.count_dir = msg.directory + '/_page_count'; return msg;`,
+      func: `msg.count_dir = msg.directory + '/_page_count';
+return msg;`,
     })
     .then('b10003', 'Core.FileSystem.Create', 'Ensure Count Dir', {
       inPath: Message('count_dir'),
@@ -24,7 +25,10 @@ subflow.create('Get Page Count', (f) => {
       outFiles: Message('count_files'),
     })
     .then('b10006', 'Core.Programming.Function', 'Count And Cleanup', {
-      func: `var list = msg.count_files || []; var pages = 0; for (var i = 0; i < list.length; i++) { if (!list[i].IsDir) pages++; } msg.page_count = pages || 1; return msg;`,
+      func: `var list = msg.count_files || [];
+var pages = 0;
+for (var i = 0; i < list.length; i++) { if (!list[i].IsDir) pages++; } msg.page_count = pages || 1;
+return msg;`,
     })
     .then('b10007', 'Core.FileSystem.Delete', 'Cleanup Count Dir', {
       inPath: Message('count_dir'),

--- a/split-pdf-by-half/subflows/a10021.ts
+++ b/split-pdf-by-half/subflows/a10021.ts
@@ -3,7 +3,10 @@ import { subflow, Message } from '@robomotion/sdk';
 subflow.create('Compute Half', (f) => {
   f.node('c10001', 'Core.Flow.Begin', 'Begin', {})
     .then('c10002', 'Core.Programming.Function', 'Even Or Odd', {
-      func: `var c = Number(msg.page_count) || 0; msg.even = (c % 2) === 0; msg.half = msg.even ? (c / 2) : ((c - 1) / 2); return msg;`,
+      func: `var c = Number(msg.page_count) || 0;
+msg.even = (c % 2) === 0;
+msg.half = msg.even ? (c / 2) : ((c - 1) / 2);
+return msg;`,
     })
     .then('c10003', 'Core.Flow.End', 'End', { sfPort: 0 });
 });

--- a/split-pdf-by-half/subflows/a11000.ts
+++ b/split-pdf-by-half/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/split-pdf-by-half/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_pdf = fixtures + '/sample.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/split-pdf-by-half/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_pdf = fixtures + '/sample.pdf';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/split-pdf-by-specified-page/main.ts
+++ b/split-pdf-by-specified-page/main.ts
@@ -8,7 +8,8 @@ const myFlow = flow.create('6474eb64-a9c9-4919-8ff2-a3de299ec8a9', 'Imported Spl
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10020', 'Core.Programming.Function', 'Build Default', {
-      func: `msg.default_pdf = global.get('$Home$') + '/templates/pdf-automation/split-pdf-by-specified-page/fixtures/sample.pdf'; return msg;`,
+      func: `msg.default_pdf = global.get('$Home$') + '/templates/pdf-automation/split-pdf-by-specified-page/fixtures/sample.pdf';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask PDF', {
       inTitle: Custom('Split a PDF into two parts'),
@@ -24,7 +25,19 @@ const myFlow = flow.create('6474eb64-a9c9-4919-8ff2-a3de299ec8a9', 'Imported Spl
     })
     .then('a10004', 'Core.Programming.Function', 'Validate Inputs', {
       outputs: 2,
-      func: `var n = Number(msg.split_at_text); if (!msg.pdf_path || !/\\.pdf$/i.test(msg.pdf_path) || !Number.isInteger(n) || n < 1) return [null, msg]; msg.split_at_page = n; var p = msg.pdf_path; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); msg.directory = p.substring(0, lastSlash); var base = p.substring(lastSlash + 1); var dot = base.lastIndexOf('.'); msg.stem = dot === -1 ? base : base.substring(0, dot); var stamp = Date.now(); msg.pages_dir = msg.directory + '/_pages_' + stamp; msg.split_output_dir = msg.directory + '/split_parts_' + stamp; return [msg, null];`,
+      func: `var n = Number(msg.split_at_text);
+if (!msg.pdf_path || !/\\.pdf$/i.test(msg.pdf_path) || !Number.isInteger(n) || n < 1) return [null, msg];
+msg.split_at_page = n;
+var p = msg.pdf_path;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+msg.directory = p.substring(0, lastSlash);
+var base = p.substring(lastSlash + 1);
+var dot = base.lastIndexOf('.');
+msg.stem = dot === -1 ? base : base.substring(0, dot);
+var stamp = Date.now();
+msg.pages_dir = msg.directory + '/_pages_' + stamp;
+msg.split_output_dir = msg.directory + '/split_parts_' + stamp;
+return [msg, null];`,
     });
 
   f.node('a10005', 'Core.FileSystem.Create', 'Ensure Pages Dir', {
@@ -48,7 +61,17 @@ const myFlow = flow.create('6474eb64-a9c9-4919-8ff2-a3de299ec8a9', 'Imported Spl
     })
     .then('a10008', 'Core.Programming.Function', 'Plan Halves', {
       outputs: 2,
-      func: `var list = (msg.page_files || []).filter(function (x) { return !x.IsDir; }); list.sort(function (a, b) { return a.Name < b.Name ? -1 : (a.Name > b.Name ? 1 : 0); }); var c = list.length; var n = Number(msg.split_at_page); if (!c || c < 2 || n < 1 || n >= c) return [null, msg]; msg.page_count = c; msg.first_paths = list.slice(0, n).map(function (x) { return x.Name; }); msg.second_paths = list.slice(n).map(function (x) { return x.Name; }); msg.first_out = msg.split_output_dir + '/' + msg.stem + '-1.pdf'; msg.second_out = msg.split_output_dir + '/' + msg.stem + '-2.pdf'; return [msg, null];`,
+      func: `var list = (msg.page_files || []).filter(function (x) { return !x.IsDir; });
+list.sort(function (a, b) { return a.Name < b.Name ? -1 : (a.Name > b.Name ? 1 : 0); });
+var c = list.length;
+var n = Number(msg.split_at_page);
+if (!c || c < 2 || n < 1 || n >= c) return [null, msg];
+msg.page_count = c;
+msg.first_paths = list.slice(0, n).map(function (x) { return x.Name; });
+msg.second_paths = list.slice(n).map(function (x) { return x.Name; });
+msg.first_out = msg.split_output_dir + '/' + msg.stem + '-1.pdf';
+msg.second_out = msg.split_output_dir + '/' + msg.stem + '-2.pdf';
+return [msg, null];`,
     });
 
   f.node('a10009', 'Core.FileSystem.Create', 'Ensure Split Dir', {
@@ -69,7 +92,8 @@ const myFlow = flow.create('6474eb64-a9c9-4919-8ff2-a3de299ec8a9', 'Imported Spl
       continueOnError: true,
     })
     .then('a10013', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'The output PDF files have been saved in:\\n' + msg.split_output_dir; return msg;`,
+      func: `msg.dialog_text = 'The output PDF files have been saved in:\\n' + msg.split_output_dir;
+return msg;`,
     })
     .then('a10014', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('Flow has been completed!'),

--- a/split-pdf-by-specified-page/subflows/a11000.ts
+++ b/split-pdf-by-specified-page/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/split-pdf-by-specified-page/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_pdf = fixtures + '/sample.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/split-pdf-by-specified-page/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_pdf = fixtures + '/sample.pdf';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/split-pdf-into-parts/main.ts
+++ b/split-pdf-into-parts/main.ts
@@ -8,7 +8,8 @@ const myFlow = flow.create('d96f25dd-50c0-4d51-a885-fbc3b8977c1d', 'Imported Spl
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a11000', 'Core.Flow.SubFlow', 'Download Fixtures', {})
     .then('a10040', 'Core.Programming.Function', 'Build Default', {
-      func: `msg.default_pdf = global.get('$Home$') + '/templates/pdf-automation/split-pdf-into-parts/fixtures/sample.pdf'; return msg;`,
+      func: `msg.default_pdf = global.get('$Home$') + '/templates/pdf-automation/split-pdf-into-parts/fixtures/sample.pdf';
+return msg;`,
     })
     .then('a10002', 'Core.Dialog.InputBox', 'Ask PDF', {
       inTitle: Custom('Split a PDF file'),
@@ -24,7 +25,16 @@ const myFlow = flow.create('d96f25dd-50c0-4d51-a885-fbc3b8977c1d', 'Imported Spl
     })
     .then('a10004', 'Core.Programming.Function', 'Validate', {
       outputs: 2,
-      func: `var n = Number(msg.n_text); if (!msg.pdf_path || !/\\.pdf$/i.test(msg.pdf_path) || !Number.isInteger(n) || n < 1) return [null, msg]; msg.pages_per_part = n; var p = msg.pdf_path; var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\')); msg.directory = p.substring(0, lastSlash); var stamp = Date.now(); msg.pages_dir = msg.directory + '/_pages_' + stamp; msg.split_output_dir = msg.directory + '/parts_' + stamp; return [msg, null];`,
+      func: `var n = Number(msg.n_text);
+if (!msg.pdf_path || !/\\.pdf$/i.test(msg.pdf_path) || !Number.isInteger(n) || n < 1) return [null, msg];
+msg.pages_per_part = n;
+var p = msg.pdf_path;
+var lastSlash = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\\\'));
+msg.directory = p.substring(0, lastSlash);
+var stamp = Date.now();
+msg.pages_dir = msg.directory + '/_pages_' + stamp;
+msg.split_output_dir = msg.directory + '/parts_' + stamp;
+return [msg, null];`,
     });
 
   f.node('a10005', 'Core.FileSystem.Create', 'Ensure Pages Dir', {
@@ -47,7 +57,14 @@ const myFlow = flow.create('d96f25dd-50c0-4d51-a885-fbc3b8977c1d', 'Imported Spl
       outFiles: Message('page_files'),
     })
     .then('a10008', 'Core.Programming.Function', 'Build Chunks', {
-      func: `var list = (msg.page_files || []).filter(function (x) { return !x.IsDir; }); list.sort(function (a, b) { return a.Name < b.Name ? -1 : (a.Name > b.Name ? 1 : 0); }); var paths = list.map(function (x) { return x.Name; }); var n = Number(msg.pages_per_part); var chunks = []; for (var i = 0; i < paths.length; i += n) chunks.push(paths.slice(i, i + n)); msg.chunks = chunks; return msg;`,
+      func: `var list = (msg.page_files || []).filter(function (x) { return !x.IsDir; });
+list.sort(function (a, b) { return a.Name < b.Name ? -1 : (a.Name > b.Name ? 1 : 0); });
+var paths = list.map(function (x) { return x.Name; });
+var n = Number(msg.pages_per_part);
+var chunks = [];
+for (var i = 0; i < paths.length; i += n) chunks.push(paths.slice(i, i + n));
+msg.chunks = chunks;
+return msg;`,
     })
     .then('a10009', 'Core.FileSystem.Create', 'Ensure Output Dir', {
       inPath: Message('split_output_dir'),
@@ -75,7 +92,8 @@ const myFlow = flow.create('d96f25dd-50c0-4d51-a885-fbc3b8977c1d', 'Imported Spl
     continueOnError: true,
   })
     .then('a10031', 'Core.Programming.Function', 'Build Done Text', {
-      func: `msg.dialog_text = 'The output PDF files are located in:\\n' + msg.split_output_dir; return msg;`,
+      func: `msg.dialog_text = 'The output PDF files are located in:\\n' + msg.split_output_dir;
+return msg;`,
     })
     .then('a10032', 'Core.Dialog.MessageBox', 'Show Done', {
       inTitle: Custom('Flow ran successfully!'),

--- a/split-pdf-into-parts/subflows/a10050.ts
+++ b/split-pdf-into-parts/subflows/a10050.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Merge Chunk', (f) => {
   f.node('b10001', 'Core.Flow.Begin', 'Begin', {})
     .then('b10002', 'Core.Programming.Function', 'Build Chunk Target', {
-      func: `var idx = msg.current_index; msg.chunk_paths = msg.current_chunk || []; msg.chunk_out = msg.split_output_dir + '/Output Split_' + (idx + 1) + '.pdf'; return msg;`,
+      func: `var idx = msg.current_index;
+msg.chunk_paths = msg.current_chunk || [];
+msg.chunk_out = msg.split_output_dir + '/Output Split_' + (idx + 1) + '.pdf';
+return msg;`,
     })
     .then('b10003', 'Robomotion.PDFBox.Merge', 'Merge Chunk', {
       inPaths: Message('chunk_paths'),

--- a/split-pdf-into-parts/subflows/a11000.ts
+++ b/split-pdf-into-parts/subflows/a11000.ts
@@ -3,7 +3,10 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('Download Fixtures', (f) => {
   f.node('b11001', 'Core.Flow.Begin', 'Begin', {})
     .then('b11002', 'Core.Programming.Function', 'Build Paths', {
-      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/split-pdf-into-parts/fixtures'; msg._dl_dir = fixtures; msg._dl_sample_pdf = fixtures + '/sample.pdf'; return msg;`,
+      func: `var fixtures = global.get('$Home$') + '/templates/pdf-automation/split-pdf-into-parts/fixtures';
+msg._dl_dir = fixtures;
+msg._dl_sample_pdf = fixtures + '/sample.pdf';
+return msg;`,
     })
     .then('b11003', 'Core.FileSystem.Create', 'Create Fixtures Dir', {
       inPath: Message('_dl_dir'),

--- a/take-screenshot-of-web-page/main.ts
+++ b/take-screenshot-of-web-page/main.ts
@@ -14,11 +14,16 @@ const myFlow = flow.create('b3bf6a71-ad35-4750-819d-d5f687a182fd', 'Imported Tak
     })
     .then('a10003', 'Core.Programming.Function', 'Branch On Cancel', {
       outputs: 2,
-      func: `var u = (msg.url_input || '').trim(); if (!u) return [null, msg]; if (!/^https?:\\/\\//i.test(u)) u = 'https://' + u; msg.url = u; return [msg, null];`,
+      func: `var u = (msg.url_input || '').trim();
+if (!u) return [null, msg];
+if (!/^https?:\\/\\//i.test(u)) u = 'https://' + u; msg.url = u; return [msg, null];`,
     });
 
   f.node('a10004', 'Core.Programming.Function', 'Build Screenshot Path', {
-    func: `msg.desktop_path = global.get('$Home$') + '/Desktop'; msg.screenshot_path = msg.desktop_path + '/ScreenShot.png'; msg.retry_count = 0; return msg;`,
+    func: `msg.desktop_path = global.get('$Home$') + '/Desktop';
+msg.screenshot_path = msg.desktop_path + '/ScreenShot.png';
+msg.retry_count = 0;
+return msg;`,
   })
     .then('a10040', 'Core.Flow.GoTo', 'Enter Retry', {
       optNodes: { type: 'goto', ids: ['a10041'], all: false },
@@ -57,7 +62,8 @@ const myFlow = flow.create('b3bf6a71-ad35-4750-819d-d5f687a182fd', 'Imported Tak
       outFormattedTime: Message('stamp'),
     })
     .then('a10011', 'Core.Programming.Function', 'Build Stamped Path', {
-      func: `msg.renamed_path = msg.desktop_path + '/ScreenShot-' + msg.stamp + '.png'; return msg;`,
+      func: `msg.renamed_path = msg.desktop_path + '/ScreenShot-' + msg.stamp + '.png';
+return msg;`,
     })
     .then('a10012', 'Core.FileSystem.Move', 'Rename Screenshot', {
       inSrcPath: Message('screenshot_path'),
@@ -65,7 +71,8 @@ const myFlow = flow.create('b3bf6a71-ad35-4750-819d-d5f687a182fd', 'Imported Tak
       continueOnError: true,
     })
     .then('a10013', 'Core.Programming.Function', 'Build Results Text', {
-      func: `msg.dialog_text = 'The screenshot is stored at:\\n\\n' + msg.renamed_path; return msg;`,
+      func: `msg.dialog_text = 'The screenshot is stored at:\\n\\n' + msg.renamed_path;
+return msg;`,
     })
     .then('a10014', 'Core.Dialog.MessageBox', 'Show Result', {
       inTitle: Custom('Screenshot taken!'),
@@ -78,7 +85,8 @@ const myFlow = flow.create('b3bf6a71-ad35-4750-819d-d5f687a182fd', 'Imported Tak
   })
     .then('a10051', 'Core.Programming.Function', 'Check Retry', {
       outputs: 2,
-      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1; return [msg, null]; } return [null, msg];`,
+      func: `if ((msg.retry_count || 0) < 1) { msg.retry_count = (msg.retry_count || 0) + 1;
+return [msg, null]; } return [null, msg];`,
     });
 
   f.node('a10052', 'Core.Programming.Sleep', 'Wait 2s', {

--- a/use-and-operator-in-conditionals/main.ts
+++ b/use-and-operator-in-conditionals/main.ts
@@ -5,7 +5,9 @@ const myFlow = flow.create('2077b07b-5e22-433b-97dc-1df0970dc29e', 'Imported Use
 
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a10002', 'Core.Programming.Function', 'Seed Inputs', {
-      func: `msg.tool = 'Robomotion'; msg.company = 'Robomotion Inc.'; return msg;`,
+      func: `msg.tool = 'Robomotion';
+msg.company = 'Robomotion Inc.';
+return msg;`,
     })
     .then('a10003', 'Core.Programming.Function', 'AND Test', {
       outputs: 2,

--- a/use-conditionals-to-check-if-file-exists/main.ts
+++ b/use-conditionals-to-check-if-file-exists/main.ts
@@ -16,7 +16,9 @@ const myFlow = flow.create('35cba3e6-c333-42f1-86af-2092663a6f7c', 'Imported Use
     });
 
   f.node('a10004', 'Core.Programming.Function', 'Build Desktop Path', {
-    func: `var desktop = global.get('$Home$') + '/Desktop'; msg.candidate_path = desktop + '/' + msg.user_input; return msg;`,
+    func: `var desktop = global.get('$Home$') + '/Desktop';
+msg.candidate_path = desktop + '/' + msg.user_input;
+return msg;`,
   })
     .then('a10005', 'Core.FileSystem.PathExists', 'Path Exists?', {
       inPath: Message('candidate_path'),
@@ -28,7 +30,8 @@ const myFlow = flow.create('35cba3e6-c333-42f1-86af-2092663a6f7c', 'Imported Use
     });
 
   f.node('a10007', 'Core.Programming.Function', 'Build Found Text', {
-    func: `msg.dialog_text = "Filename: '" + msg.user_input + "' exists in your desktop folder."; return msg;`,
+    func: `msg.dialog_text = "Filename: '" + msg.user_input + "' exists in your desktop folder.";
+return msg;`,
   })
     .then('a10008', 'Core.Dialog.MessageBox', 'Show Found', {
       inTitle: Custom('File found!'),
@@ -37,7 +40,8 @@ const myFlow = flow.create('35cba3e6-c333-42f1-86af-2092663a6f7c', 'Imported Use
     });
 
   f.node('a10009', 'Core.Programming.Function', 'Build Missing Text', {
-    func: `msg.dialog_text = "Filename: '" + msg.user_input + "' doesn't exist in your desktop folder."; return msg;`,
+    func: `msg.dialog_text = "Filename: '" + msg.user_input + "' doesn't exist in your desktop folder.";
+return msg;`,
   })
     .then('a10010', 'Core.Dialog.MessageBox', 'Show Missing', {
       inTitle: Custom('File not found!'),

--- a/use-labels-to-check-if-file-exists/main.ts
+++ b/use-labels-to-check-if-file-exists/main.ts
@@ -16,7 +16,9 @@ const myFlow = flow.create('7449d9f1-2aa8-4091-bcf3-84fdad6670b0', 'Imported Use
     });
 
   f.node('a10004', 'Core.Programming.Function', 'Build Desktop Path', {
-    func: `var desktop = global.get('$Home$') + '/Desktop'; msg.candidate_path = desktop + '/' + msg.user_input; return msg;`,
+    func: `var desktop = global.get('$Home$') + '/Desktop';
+msg.candidate_path = desktop + '/' + msg.user_input;
+return msg;`,
   })
     .then('a10005', 'Core.FileSystem.PathExists', 'Path Exists?', {
       inPath: Message('candidate_path'),
@@ -37,7 +39,8 @@ const myFlow = flow.create('7449d9f1-2aa8-4091-bcf3-84fdad6670b0', 'Imported Use
 
   f.node('a10020', 'Core.Flow.Label', 'File_Exists', {})
     .then('a10021', 'Core.Programming.Function', 'Build Found Text', {
-      func: `msg.dialog_text = "Filename: '" + msg.user_input + "' exists in your desktop folder."; return msg;`,
+      func: `msg.dialog_text = "Filename: '" + msg.user_input + "' exists in your desktop folder.";
+return msg;`,
     })
     .then('a10022', 'Core.Dialog.MessageBox', 'Show Found', {
       inTitle: Custom('File found!'),
@@ -48,7 +51,8 @@ const myFlow = flow.create('7449d9f1-2aa8-4091-bcf3-84fdad6670b0', 'Imported Use
 
   f.node('a10030', 'Core.Flow.Label', 'File_Does_Not_Exist', {})
     .then('a10031', 'Core.Programming.Function', 'Build Missing Text', {
-      func: `msg.dialog_text = "Filename: '" + msg.user_input + "' doesn't exist in your desktop folder."; return msg;`,
+      func: `msg.dialog_text = "Filename: '" + msg.user_input + "' doesn't exist in your desktop folder.";
+return msg;`,
     })
     .then('a10032', 'Core.Dialog.MessageBox', 'Show Missing', {
       inTitle: Custom('File not found!'),

--- a/use-or-operator-in-conditionals/main.ts
+++ b/use-or-operator-in-conditionals/main.ts
@@ -5,7 +5,9 @@ const myFlow = flow.create('12ed202a-d649-4f9d-bbe9-60e3000d2b65', 'Imported Use
 
   f.node('a10001', 'Core.Trigger.Inject', 'Start', {})
     .then('a10002', 'Core.Programming.Function', 'Seed Inputs', {
-      func: `msg.tool = 'Robomotion'; msg.company = 'Some Other Corp'; return msg;`,
+      func: `msg.tool = 'Robomotion';
+msg.company = 'Some Other Corp';
+return msg;`,
     })
     .then('a10003', 'Core.Programming.Function', 'OR Test', {
       outputs: 2,

--- a/use-subflows-to-check-if-file-exists/main.ts
+++ b/use-subflows-to-check-if-file-exists/main.ts
@@ -16,7 +16,9 @@ const myFlow = flow.create('a45b07c3-25ee-453c-9c35-3f54f6edcb21', 'Imported Use
     });
 
   f.node('a10004', 'Core.Programming.Function', 'Build Desktop Path', {
-    func: `var desktop = global.get('$Home$') + '/Desktop'; msg.candidate_path = desktop + '/' + msg.user_input; return msg;`,
+    func: `var desktop = global.get('$Home$') + '/Desktop';
+msg.candidate_path = desktop + '/' + msg.user_input;
+return msg;`,
   })
     .then('a10005', 'Core.FileSystem.PathExists', 'Path Exists?', {
       inPath: Message('candidate_path'),

--- a/use-subflows-to-check-if-file-exists/subflows/a10007.ts
+++ b/use-subflows-to-check-if-file-exists/subflows/a10007.ts
@@ -3,7 +3,8 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('File Exists', (f) => {
   f.node('b10001', 'Core.Flow.Begin', 'Begin', {})
     .then('b10002', 'Core.Programming.Function', 'Build Found Text', {
-      func: `msg.dialog_text = "Filename: '" + msg.user_input + "' exists in your desktop folder."; return msg;`,
+      func: `msg.dialog_text = "Filename: '" + msg.user_input + "' exists in your desktop folder.";
+return msg;`,
     })
     .then('b10003', 'Core.Dialog.MessageBox', 'Show Found', {
       inTitle: Custom('File found!'),

--- a/use-subflows-to-check-if-file-exists/subflows/a10008.ts
+++ b/use-subflows-to-check-if-file-exists/subflows/a10008.ts
@@ -3,7 +3,8 @@ import { subflow, Message, Custom } from '@robomotion/sdk';
 subflow.create('File Does Not Exist', (f) => {
   f.node('c10001', 'Core.Flow.Begin', 'Begin', {})
     .then('c10002', 'Core.Programming.Function', 'Build Missing Text', {
-      func: `msg.dialog_text = "Filename: '" + msg.user_input + "' doesn't exist in your desktop folder."; return msg;`,
+      func: `msg.dialog_text = "Filename: '" + msg.user_input + "' doesn't exist in your desktop folder.";
+return msg;`,
     })
     .then('c10003', 'Core.Dialog.MessageBox', 'Show Missing', {
       inTitle: Custom('File not found!'),


### PR DESCRIPTION
## Summary
- `Core.Programming.Function` nodes using backtick-template `func` values previously packed all statements on one line (`; ` separated), making the body hard to read when the node is opened in the designer.
- Insert a newline after each top-level `;` (outside string literals, parens, comments) so each statement renders on its own line.
- 95 files changed, 711 insertions / 196 deletions.

## Safety
- Only touches backtick-quoted `func` values on `Core.Programming.Function` nodes — other node types (`LLMAgent`, `SQLite.Query`, etc.) and single-quoted funcs are untouched.
- State machine skips `;` inside string literals (`'..'`, `".."`, `` `..` ``), inside `(..)` (so `for (;;)` and `.map(...)` internals are preserved), and inside `//` / `/* */` comments.
- Only replaces `; ` → `;\n` when the space is followed by a letter / `_` / `$` (start of a new statement).
- Validated: for every modified func, normalizing all out-of-string whitespace runs to a single space yields an identical string before and after. Since JS treats space and newline identically as whitespace, behaviour is preserved.

## Test plan
- [ ] Open a few representative templates in the designer and verify the Function body now spans multiple lines (e.g. `launch-excel-and-extract-table` → `Build Default Path`, `bmi-calculator`, `create-pdf-from-selected-pages`).
- [ ] Run one template end-to-end to confirm runtime behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)