### PR TITLE
Drop extract-tables-from-pdf from featured

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -693,7 +693,6 @@ templates:
 
   - name: Extract Tables from PDF
     slug: extract-tables-from-pdf
-    featured: true
     summary: >-
       Locates tables inside a PDF and extracts their rows into structured data. A
       drop-in stage in any OCR-adjacent pipeline.


### PR DESCRIPTION
Removes the `featured: true` flag from `extract-tables-from-pdf`, leaving six featured templates for the designer's **Featured Templates** section:

- `generic-chat-assistant`
- `fork-branch-with-memory-queue`
- `domain-inspector`
- `ssl-watch`
- `manipulate-excel-data-using-sql`
- `handle-errors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)