### PR TITLE
Use headed chrome (not headlesschrome) in browser Open nodes

### DIFF
--- a/bank-reconciliation/main.ts
+++ b/bank-reconciliation/main.ts
@@ -43,7 +43,7 @@ msg.findings = [];
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open ERP Login', {
       inBrowserId: Message('browser'), inUrl: Message('rap_login'), outPageId: Message('page')

--- a/bulk-shipment-tracking-sweep/main.ts
+++ b/bulk-shipment-tracking-sweep/main.ts
@@ -41,7 +41,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Reader Browser', {
-      optBrowser: 'headlesschrome',
+      optBrowser: 'chrome',
       outBrowserId: Message('reader_browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Bulk Page', {
@@ -105,7 +105,7 @@ return msg;`
   f.edge('b20000', 0, 'b2000f', 0);
 
   f.node('b20001', 'Core.Browser.Open', 'Worker Browser', {
-    optBrowser: 'headlesschrome',
+    optBrowser: 'chrome',
     optUserDataDir: Message('user_data_dir'),
     outBrowserId: Message('worker_browser')
   });

--- a/clinic-eligibility-morning-run/main.ts
+++ b/clinic-eligibility-morning-run/main.ts
@@ -54,7 +54,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Reader Browser', {
-      optBrowser: 'headlesschrome',
+      optBrowser: 'chrome',
       outBrowserId: Message('reader_browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Login Page', {
@@ -161,7 +161,7 @@ return msg;`
   f.edge('b20000', 0, 'b20001', 0);
 
   f.node('b20002', 'Core.Browser.Open', 'Worker Browser', {
-    optBrowser: 'headlesschrome',
+    optBrowser: 'chrome',
     optUserDataDir: Message('user_data_dir'),
     outBrowserId: Message('worker_browser')
   });

--- a/crm-duplicate-cleanup/main.ts
+++ b/crm-duplicate-cleanup/main.ts
@@ -36,7 +36,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Login', {
       inBrowserId: Message('browser'), inUrl: Message('login_url'), outPageId: Message('page')

--- a/denial-worklist-triage/main.ts
+++ b/denial-worklist-triage/main.ts
@@ -58,7 +58,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome',
+      optBrowser: 'chrome',
       outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Login Page', {

--- a/einvoice-portal-harvest/main.ts
+++ b/einvoice-portal-harvest/main.ts
@@ -64,7 +64,7 @@ return msg;`
       outPath: Message('download_dir_created')
     })
     .then('a10004', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome',
+      optBrowser: 'chrome',
       optDownloadDir: Message('download_dir'),
       outBrowserId: Message('browser')
     })

--- a/friday-payment-run/main.ts
+++ b/friday-payment-run/main.ts
@@ -41,7 +41,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Login', {
       inBrowserId: Message('browser'), inUrl: Message('login_url'), outPageId: Message('page')

--- a/invoice-inbox-to-ledger/main.ts
+++ b/invoice-inbox-to-ledger/main.ts
@@ -42,7 +42,7 @@ msg.results = [];
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Mailbox', {
       inBrowserId: Message('browser'), inUrl: Message('lookout_url'), outPageId: Message('page')

--- a/leave-request-policing/main.ts
+++ b/leave-request-policing/main.ts
@@ -43,7 +43,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Login', {
       inBrowserId: Message('browser'), inUrl: Message('login_url'), outPageId: Message('page')

--- a/logistics-exception-center/main.ts
+++ b/logistics-exception-center/main.ts
@@ -45,7 +45,7 @@ msg.ticketed = [];
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Carrier Login', {
       inBrowserId: Message('browser'), inUrl: Message('slug_login'), outPageId: Message('page')

--- a/monday-morning-briefing/main.ts
+++ b/monday-morning-briefing/main.ts
@@ -60,7 +60,7 @@ msg.briefing = [];
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     // ---------------------------------------------------- 1. CRM duplicates (Zapspot)
     .then('a10004', 'Core.Browser.OpenLink', 'Open CRM Login', {

--- a/payroll-validation-gate/main.ts
+++ b/payroll-validation-gate/main.ts
@@ -40,7 +40,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Login', {
       inBrowserId: Message('browser'), inUrl: Message('login_url'), outPageId: Message('page')

--- a/portal-erp-reconciliation/main.ts
+++ b/portal-erp-reconciliation/main.ts
@@ -48,7 +48,7 @@ msg.pages = [];
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Login Page', {
       inBrowserId: Message('browser'), inUrl: Message('frs_login'), outPageId: Message('page')

--- a/quote-to-cash-gap-audit/main.ts
+++ b/quote-to-cash-gap-audit/main.ts
@@ -35,7 +35,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Login', {
       inBrowserId: Message('browser'), inUrl: Message('login_url'), outPageId: Message('page')

--- a/refund-request-triage/main.ts
+++ b/refund-request-triage/main.ts
@@ -54,7 +54,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Bank Login', {
       inBrowserId: Message('browser'), inUrl: Message('ab_url'), outPageId: Message('page')

--- a/tax-portal-morning-board/main.ts
+++ b/tax-portal-morning-board/main.ts
@@ -47,7 +47,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Login', {
       inBrowserId: Message('browser'), inUrl: Message('login_url'), outPageId: Message('page')

--- a/vendor-onboarding/main.ts
+++ b/vendor-onboarding/main.ts
@@ -45,7 +45,7 @@ msg.t0 = Date.now();
 return msg;`
     })
     .then('a10003', 'Core.Browser.Open', 'Open Browser', {
-      optBrowser: 'headlesschrome', outBrowserId: Message('browser')
+      optBrowser: 'chrome', outBrowserId: Message('browser')
     })
     .then('a10004', 'Core.Browser.OpenLink', 'Open Mailbox', {
       inBrowserId: Message('browser'), inUrl: Message('lookout_url'), outPageId: Message('page')


### PR DESCRIPTION
## What

Switches every `Core.Browser.Open` node in all 17 use-case templates from `optBrowser: 'headlesschrome'` to `optBrowser: 'chrome'` — runs now open a visible Chrome window instead of running headless.

## Scope

- **19 nodes across 17 `main.ts` files.** `bulk-shipment-tracking-sweep` and `clinic-eligibility-morning-run` have 2 each (parallel browser workers); the rest have 1.
- Only `main.ts` changed — browser mode doesn't affect the designer layout or the screenshots, so nothing was regenerated.

## Testing

All 17 pass `robomotion validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
