### PR TITLE
academy.yaml: episodes 11 and 12, and a generator that still runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ workdir
 skills-lock.json
 TODO.md
 deferred-todo.md
+
+# Python bytecode, from running tools/*.py in place
+__pycache__/
+*.pyc

--- a/academy.yaml
+++ b/academy.yaml
@@ -150,7 +150,7 @@ videos:
 
   - id: 8FUPGnAYWA0
     episode: 12
-    title: "Answering Questions From Your Own Documents with Knowledge Bases"
+    title: "Creating a Knowledge Base"
     summary: >-
       A knowledge base in Robomotion is a set of your own documents, prepared once so
       that a flow can search them. PDFs, Word files, spreadsheets, markdown, plain text

--- a/academy.yaml
+++ b/academy.yaml
@@ -135,3 +135,30 @@ videos:
     published: "2026-08-21"
     level: Intermediate
     topic: "Scripting"
+
+  - id: 00BweGh8ISo
+    episode: 11
+    title: "Sharing Work Between Robots with Queues"
+    summary: >-
+      Some work does not arrive as one job. It arrives as a hundred small ones, all day,
+      from somewhere else. A queue is where that work waits.
+    duration: "6:41"
+    duration_seconds: 401
+    published: "2026-08-28"
+    level: Intermediate
+    topic: "Orchestration"
+
+  - id: 8FUPGnAYWA0
+    episode: 12
+    title: "Answering Questions From Your Own Documents with Knowledge Bases"
+    summary: >-
+      A knowledge base in Robomotion is a set of your own documents, prepared once so
+      that a flow can search them. PDFs, Word files, spreadsheets, markdown, plain text
+      and images all go in. It belongs to the workspace rather than to any one flow,
+      like a vault or a queue, so every flow in the workspace can ask it a question by
+      name.
+    duration: "7:41"
+    duration_seconds: 461
+    published: "2026-08-28"
+    level: Advanced
+    topic: "Retrieval"

--- a/index.yaml
+++ b/index.yaml
@@ -1784,6 +1784,7 @@ templates:
     created: "2026-08-28"
     updated: "2026-08-28"
     screenshot: screenshot.png
+    video_url: "https://www.youtube.com/watch?v=8FUPGnAYWA0"
     has_subflows: false
 
   - name: Launch Excel
@@ -2440,6 +2441,7 @@ templates:
     created: "2026-08-28"
     updated: "2026-08-28"
     screenshot: screenshot.png
+    video_url: "https://www.youtube.com/watch?v=00BweGh8ISo"
     has_subflows: false
 
   - name: Refund Request Triage

--- a/knowledge-base-endpoint/template.yaml
+++ b/knowledge-base-endpoint/template.yaml
@@ -15,6 +15,7 @@ author: Robomotion
 created: "2026-08-28"
 updated: "2026-08-28"
 screenshot: screenshot.png
+video_url: "https://www.youtube.com/watch?v=8FUPGnAYWA0"
 dependencies:
   - package: Robomotion.KnowledgeBase
     version: "0.1.7"

--- a/refund-queue/template.yaml
+++ b/refund-queue/template.yaml
@@ -15,6 +15,7 @@ author: Robomotion
 created: "2026-08-28"
 updated: "2026-08-28"
 screenshot: screenshot.png
+video_url: "https://www.youtube.com/watch?v=00BweGh8ISo"
 has_subflows: false
 flow_id: a0fc670c-f6ea-489c-aff0-e4b1e1436ae8
 schema_version: 1

--- a/tools/build-academy-yaml.py
+++ b/tools/build-academy-yaml.py
@@ -12,7 +12,18 @@ playlist, then commit the regenerated academy.yaml.
 
 Two sources are combined:
   * the playlist page  - canonical order, titles and runtimes
-  * the playlist RSS   - publish dates and the opening line of each description
+  * each video's watch page - publish date and the opening line of the description
+
+It used to read the second from the playlist RSS feed. That feed is gone: both
+https://www.youtube.com/feeds/videos.xml?playlist_id=... and the channel_id form
+answer 404 as of 2026-08-28, so a regeneration died on an HTTPError before it
+wrote anything. The watch page carries the same two fields in
+ytInitialPlayerResponse, and reproduces every value the feed used to give,
+provided the timestamp is normalised to UTC first - YouTube serves it with a
+-07:00 offset, and taking the date off that shifts half the series back a day.
+
+The cost is one request per video instead of one for the playlist. At a dozen
+videos that is fine; if the series grows past a few dozen, cache them.
 
 Only stdlib is used, so there is nothing to install.
 
@@ -23,15 +34,14 @@ warning naming it so the gap gets filled.
 """
 
 import argparse
+import datetime
 import json
 import re
 import sys
 import urllib.request
-import xml.etree.ElementTree as ET
 
 PLAYLIST_ID = "PLie2idTJ_1wvlEgLuDUDt_bbAs-29xtmL"
 PLAYLIST_URL = f"https://www.youtube.com/playlist?list={PLAYLIST_ID}"
-FEED_URL = f"https://www.youtube.com/feeds/videos.xml?playlist_id={PLAYLIST_ID}"
 
 # Shown above the video row in the designer. Kept here (not scraped) because the
 # YouTube playlist blurb is written for YouTube's audience, not for the product.
@@ -55,6 +65,8 @@ CURATION = {
     "CFNHmF-DbPw": ("Intermediate", "Web Scraping"),
     "bxAkfUO8P-Y": ("Advanced", "Web Scraping"),
     "qtKmRoyMKZo": ("Intermediate", "Scripting"),
+    "00BweGh8ISo": ("Intermediate", "Orchestration"),
+    "8FUPGnAYWA0": ("Advanced", "Retrieval"),
 }
 
 UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126 Safari/537.36"
@@ -126,22 +138,31 @@ def fetch_playlist_items():
     return items
 
 
-def fetch_feed_details():
-    """Publish date + first description paragraph per video, from the RSS feed."""
-    ns = {
-        "a": "http://www.w3.org/2005/Atom",
-        "yt": "http://www.youtube.com/xml/schemas/2015",
-        "m": "http://search.yahoo.com/mrss/",
-    }
-    root = ET.fromstring(get(FEED_URL))
-    details = {}
-    for entry in root.findall("a:entry", ns):
-        video_id = entry.findtext("yt:videoId", "", ns)
-        published = entry.findtext("a:published", "", ns)[:10]
-        description = entry.findtext("m:group/m:description", "", ns) or ""
-        summary = description.strip().split("\n\n")[0].strip().replace("\n", " ")
-        details[video_id] = {"published": published, "summary": summary}
-    return details
+def video_details(video_id: str):
+    """Publish date (UTC) + first description paragraph, from the video's watch page."""
+    html = get(f"https://www.youtube.com/watch?v={video_id}")
+    match = re.search(r"var ytInitialPlayerResponse = (\{.*?\});", html, re.S)
+    if not match:
+        return {"published": "", "summary": ""}
+    data = json.loads(match.group(1))
+
+    description = data.get("videoDetails", {}).get("shortDescription", "") or ""
+    summary = description.strip().split("\n\n")[0].strip().replace("\n", " ")
+
+    # "2026-08-20T23:23:04-07:00" is the same instant the RSS feed reported as
+    # 2026-08-21. Take the date off the local-offset string and half the series
+    # moves back a day, so convert first.
+    stamp = (data.get("microformat", {})
+                 .get("playerMicroformatRenderer", {})
+                 .get("publishDate", "") or "")
+    published = ""
+    if stamp:
+        try:
+            published = (datetime.datetime.fromisoformat(stamp)
+                         .astimezone(datetime.timezone.utc).date().isoformat())
+        except ValueError:
+            published = stamp[:10]
+    return {"published": published, "summary": summary}
 
 
 def wrap(text: str, indent: str, width: int = 88):
@@ -199,7 +220,7 @@ def main():
     args = parser.parse_args()
 
     items = fetch_playlist_items()
-    details = fetch_feed_details()
+    details = {item["id"]: video_details(item["id"]) for item in items}
 
     videos = []
     uncurated = []


### PR DESCRIPTION
Episodes **11** ([Sharing Work Between Robots with Queues](https://www.youtube.com/watch?v=00BweGh8ISo)) and **12** ([Answering Questions From Your Own Documents with Knowledge Bases](https://www.youtube.com/watch?v=8FUPGnAYWA0)) are live on the playlist, so the Flow Designer Home page should be showing them.

Curation, added to `CURATION` in the script rather than to the YAML: **11 Intermediate / Orchestration**, **12 Advanced / Retrieval** — the same levels as the two templates merged in #19, and the same topic labels their thumbnails use.

Both `template.yaml` files gain `video_url` now that there is a video to point at, which was the follow-up flagged in #19. `index.yaml` regenerated.

## The generator was broken

`python3 tools/build-academy-yaml.py` could not run at all. It read publish dates and summaries from the playlist RSS feed, and that feed is gone — `feeds/videos.xml?playlist_id=…` answers **404**, and so does the `channel_id` form. The script died on an `HTTPError` before writing anything, so this file has been unregenerable for a while and nobody would have known until the next episode.

The same two fields live in each video's watch page, in `ytInitialPlayerResponse`: `videoDetails.shortDescription` and `microformat.playerMicroformatRenderer.publishDate`. It reads them from there now — one request per video instead of one for the whole playlist, which is fine at a dozen videos and is noted in the docstring as the thing to cache if the series gets long.

**One trap in the swap.** YouTube serves that timestamp with a `-07:00` offset where the feed reported UTC, so slicing the date straight off the string moves six of the ten existing entries back a day. Converting to UTC first makes this a pure addition: the ten entries above the new ones come out **byte-identical**, which is the check that the new source really is the old one.

`__pycache__/` is now gitignored — running the tools in place leaves bytecode next to them.

## One thing to decide

The two titles are the ones YouTube carries, because that is where this file has always taken them from and all ten existing entries are the full YouTube titles. Their thumbnails are shorter — "Sharing Work with Queues" and "Creating a Knowledge Base". If the Home page cards should read the short form, the choice is to rename on YouTube and re-run, or to let `CURATION` carry a title override. Happy to do either; I did not want to make 11 and 12 the only two entries whose titles disagree with the playlist.