### PR TITLE
Point the Academy templates at their episodes, and add both to academy.yaml

### DIFF
--- a/academy.yaml
+++ b/academy.yaml
@@ -150,7 +150,7 @@ videos:
 
   - id: 8FUPGnAYWA0
     episode: 12
-    title: "Creating a Knowledge Base"
+    title: "Answering Questions From Your Own Documents with Knowledge Bases"
     summary: >-
       A knowledge base in Robomotion is a set of your own documents, prepared once so
       that a flow can search them. PDFs, Word files, spreadsheets, markdown, plain text
@@ -162,3 +162,30 @@ videos:
     published: "2026-08-28"
     level: Advanced
     topic: "Retrieval"
+
+  - id: hM8DaZ0MkhU
+    episode: 13
+    title: "Collecting Data and Files From Anyone with Forms"
+    summary: >-
+      Most automation starts with something a person outside your company has to send
+      you: an application, a claim, a request, a file. A Robomotion form is how you
+      collect it, and what happens to it afterwards is the interesting part.
+    duration: "8:58"
+    duration_seconds: 538
+    published: "2026-08-29"
+    level: Intermediate
+    topic: "Intake"
+
+  - id: YnBsUuHYnRc
+    episode: 14
+    title: "Using the Chat Assistant to Talk to Your Automations"
+    summary: >-
+      Every automation you have built so far waits for somebody to hand it something. A
+      spreadsheet in a watched folder, an email, a form. And if what arrives is wrong,
+      all a robot can do is throw an exception into a log nobody reads. A chat assistant
+      lets it ask instead.
+    duration: "11:00"
+    duration_seconds: 660
+    published: "2026-08-29"
+    level: Advanced
+    topic: "Assistants"

--- a/conversational-order-assistant/template.yaml
+++ b/conversational-order-assistant/template.yaml
@@ -11,6 +11,7 @@ tags: [chat, assistant, conversational, ai, llm, agent, tools]
 author: Robomotion
 created: "2026-08-29"
 updated: "2026-08-29"
+video_url: "https://www.youtube.com/watch?v=YnBsUuHYnRc"
 dependencies:
   - package: Robomotion.ChatAssistant
     version: "1.8.6"

--- a/guided-returns-desk/template.yaml
+++ b/guided-returns-desk/template.yaml
@@ -11,6 +11,7 @@ tags: [chat, assistant, guided, support, returns, no-code]
 author: Robomotion
 created: "2026-08-29"
 updated: "2026-08-29"
+video_url: "https://www.youtube.com/watch?v=YnBsUuHYnRc"
 dependencies:
   - package: Robomotion.ChatAssistant
     version: "1.8.6"

--- a/index.yaml
+++ b/index.yaml
@@ -585,6 +585,7 @@ templates:
     created: "2026-08-29"
     updated: "2026-08-29"
     screenshot: undefined
+    video_url: "https://www.youtube.com/watch?v=YnBsUuHYnRc"
     has_subflows: false
 
   - name: Convert Datetime to Text
@@ -1524,6 +1525,7 @@ templates:
     created: "2026-08-29"
     updated: "2026-08-29"
     screenshot: undefined
+    video_url: "https://www.youtube.com/watch?v=YnBsUuHYnRc"
     has_subflows: false
 
   - name: Hacker News Front Page
@@ -1710,6 +1712,7 @@ templates:
     created: "2026-08-29"
     updated: "2026-08-29"
     screenshot: screenshot.png
+    video_url: "https://www.youtube.com/watch?v=hM8DaZ0MkhU"
     has_subflows: false
 
   - name: Invoice Inbox to Ledger

--- a/internship-application-intake/template.yaml
+++ b/internship-application-intake/template.yaml
@@ -15,6 +15,7 @@ tags: [forms, intake, queue, rsa, encryption, vault, no-code, file-upload]
 author: Robomotion
 created: "2026-08-29"
 updated: "2026-08-29"
+video_url: "https://www.youtube.com/watch?v=hM8DaZ0MkhU"
 screenshot: screenshot.png
 has_subflows: false
 flow_id: 5e030ada-80dc-443e-b7fc-5eccdc7ba9ca

--- a/tools/build-academy-yaml.py
+++ b/tools/build-academy-yaml.py
@@ -67,6 +67,8 @@ CURATION = {
     "qtKmRoyMKZo": ("Intermediate", "Scripting"),
     "00BweGh8ISo": ("Intermediate", "Orchestration"),
     "8FUPGnAYWA0": ("Advanced", "Retrieval"),
+    "hM8DaZ0MkhU": ("Intermediate", "Intake"),
+    "YnBsUuHYnRc": ("Advanced", "Assistants"),
 }
 
 UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126 Safari/537.36"


### PR DESCRIPTION
Both episodes are live, so three things follow.

## `video_url` on the three templates

| Template | Episode |
|---|---|
| [Internship Application Intake](internship-application-intake) | [Forms](https://www.youtube.com/watch?v=hM8DaZ0MkhU) |
| [Guided Returns Desk](guided-returns-desk) | [Chat Assistant](https://www.youtube.com/watch?v=YnBsUuHYnRc) |
| [Conversational Order Assistant](conversational-order-assistant) | [Chat Assistant](https://www.youtube.com/watch?v=YnBsUuHYnRc) |

The two Chat Assistant templates share a link on purpose: they are the two halves
of one episode, guided in the first half and conversational in the second.

The field sits after `updated:` and before `dependencies:`, quoted, matching
`domain-inspector` and `fork-branch-with-memory-queue`.

## `academy.yaml`

Regenerated with `tools/build-academy-yaml.py` — both videos were already in the
playlist, so the script read their titles, runtimes, publish dates and summaries
straight off YouTube. 14 videos now.

Curation added for both, because the script warns rather than guessing:

| Episode | Level | Topic |
|---|---|---|
| 13 Forms | Intermediate | Intake *(new track)* |
| 14 Chat Assistant | Advanced | Assistants *(new track)* |

## `index.yaml`

Regenerated. `build-index.js` carries `video_url` through, so this is **three
added lines and nothing else**.