### PR TITLE
Academy: episode 13's track is Forms, not Intake

### DIFF
--- a/academy.yaml
+++ b/academy.yaml
@@ -174,7 +174,7 @@ videos:
     duration_seconds: 538
     published: "2026-08-29"
     level: Intermediate
-    topic: "Intake"
+    topic: "Forms"
 
   - id: YnBsUuHYnRc
     episode: 14

--- a/tools/build-academy-yaml.py
+++ b/tools/build-academy-yaml.py
@@ -67,7 +67,7 @@ CURATION = {
     "qtKmRoyMKZo": ("Intermediate", "Scripting"),
     "00BweGh8ISo": ("Intermediate", "Orchestration"),
     "8FUPGnAYWA0": ("Advanced", "Retrieval"),
-    "hM8DaZ0MkhU": ("Intermediate", "Intake"),
+    "hM8DaZ0MkhU": ("Intermediate", "Forms"),
     "YnBsUuHYnRc": ("Advanced", "Assistants"),
 }
 


### PR DESCRIPTION
The card on the Flow Designer home page shows the topic label next to the episode
number, so it reads **13 · INTAKE** today. "Forms" is the word a viewer is
actually looking for — Intake describes the job, the feature name is what people
search for and recognise.

One line in `CURATION`, and `academy.yaml` regenerated from it. Episode 14 stays
on **Assistants**.

Diff is two lines: the curation entry and the generated topic.